### PR TITLE
Add AWS placeholders in .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For more details, follow [this guide](https://developers.zoom.us/docs/meeting-sd
 
 - Build the Docker image: `docker compose -f dev.docker-compose.yaml build` (Takes about 5 minutes)
 - Create local environment variables: `docker compose -f dev.docker-compose.yaml run --rm attendee-app-local python init_env.py > .env`
+- Edit the `.env` file and enter your AWS information.
 - Start all the services: `docker compose -f dev.docker-compose.yaml up`
 - After the services have started, run migrations in a separate terminal tab: `docker compose -f dev.docker-compose.yaml exec attendee-app-local python manage.py migrate`
 - Goto localhost:8000 in your browser and create an account

--- a/init_env.py
+++ b/init_env.py
@@ -13,6 +13,9 @@ def main():
     
     print(f'CREDENTIALS_ENCRYPTION_KEY={credentials_key}')
     print(f'DJANGO_SECRET_KEY={django_key}')
+    print(f'AWS_RECORDING_STORAGE_BUCKET_NAME=')
+    print(f'AWS_ACCESS_KEY_ID=')
+    print(f'AWS_SECRET_ACCESS_KEY=')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
@noah-duncan PR does the following: 

1. Generating .env file now adds AWS placeholders.
2. Updated local installation instructions.

The generated .env file now becomes something like this. Note the AWS placeholders. 

```
CREDENTIALS_ENCRYPTION_KEY=2aW10p58D7bT0F0NEFsAQiH_DicUebpOEtaEg4WEdR0=
DJANGO_SECRET_KEY=&8io^ejb7%k@p+%j84bs=%@9x8taq-v&xh*90uhm+3g@t%0(or
AWS_RECORDING_STORAGE_BUCKET_NAME=
AWS_ACCESS_KEY_ID=
AWS_SECRET_ACCESS_KEY=
```