### PR TITLE
add pipeline configuration object

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -10,6 +10,7 @@ from bots.bot_adapter import BotAdapter
 from .gstreamer_pipeline import GstreamerPipeline
 from .rtmp_client import RTMPClient
 from django.core.files.base import ContentFile
+from .pipeline_configuration import PipelineConfiguration
 
 import gi
 gi.require_version('GLib', '2.0')

--- a/bots/bot_controller/pipeline_configuration.py
+++ b/bots/bot_controller/pipeline_configuration.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from typing import FrozenSet, Tuple
+
+# Specifies how the bot will use the media from the meeting platform
+# For now there are only a few valid configurations, to avoid having to make the bot
+# work for every possible configuration
+@dataclass(frozen=True)
+class PipelineConfiguration:
+    record_video: bool
+    record_audio: bool
+    transcribe_audio: bool
+    rtmp_stream_audio: bool
+    rtmp_stream_video: bool
+
+    def __post_init__(self):
+        # Convert to FrozenSet of FrozenSet[str]
+        valid_configurations: FrozenSet[FrozenSet[str]] = frozenset({        
+            # Basic meeting bot configuration
+            frozenset({
+                'record_audio', 'record_video',
+                'transcribe_audio'
+            }),
+            
+            # RTMP streaming configuration
+            frozenset({
+                'rtmp_stream_audio', 'rtmp_stream_video',
+                'transcribe_audio'
+            }),
+            
+            # Voice agent configuration
+            frozenset({'transcribe_audio'}),
+        })
+
+        # Get the set of all fields that are True
+        active_fields = frozenset(
+            field for field in self.__dataclass_fields__.keys()
+            if getattr(self, field)
+        )
+        
+        # Check if this combination exists in our valid configurations
+        if active_fields not in valid_configurations:
+            raise ValueError(
+                f"Invalid configuration: {active_fields}\n"
+                f"Must be one of: {valid_configurations}"
+            )
+
+    @classmethod
+    def recorder_bot(cls) -> "PipelineConfiguration":
+        return cls(
+            record_video=True,
+            record_audio=True,
+            transcribe_audio=True,
+            rtmp_stream_audio=False,
+            rtmp_stream_video=False,
+        )
+
+    @classmethod
+    def rtmp_streaming_bot(cls) -> "PipelineConfiguration":
+        return cls(
+            record_video=False,
+            record_audio=False,
+            transcribe_audio=True,
+            rtmp_stream_audio=True,
+            rtmp_stream_video=True,
+        )
+
+    @classmethod
+    def voice_agent(cls) -> "PipelineConfiguration":
+        return cls(
+            record_video=False,
+            record_audio=False,
+            transcribe_audio=True,
+            rtmp_stream_audio=False,
+            rtmp_stream_video=False,
+        )

--- a/bots/templates/projects/project_dashboard.html
+++ b/bots/templates/projects/project_dashboard.html
@@ -9,7 +9,7 @@
                 <p class="card-text mb-0">
                     If you're building something that needs meeting bots, we'd love to chat!
                     
-                    Join our <a href="https://join.slack.com/t/attendeecommu-rff8300/shared_invite/zt-2uhpam6p2-ZzLAoVrljbL2UEjqdSHrgQ">Slack</a> or send us an <a href="mailto:crusty.noah@gmail.com">email</a>. And ⭐ us on <a href="https://github.com/noah-duncan/attendee" target="_blank" rel="noopener noreferrer">Github</a> if you find this project useful. 
+                    Join our <a href="https://join.slack.com/t/attendeecommu-rff8300/shared_invite/zt-2uhpam6p2-ZzLAoVrljbL2UEjqdSHrgQ">Slack</a> or send us an <a href="mailto:crusty.noah@gmail.com">email</a>. And please ⭐ us on <a href="https://github.com/noah-duncan/attendee" target="_blank" rel="noopener noreferrer">Github</a> if you find us useful. 
                     
                 </p>
             </div>

--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -145,6 +145,9 @@ class ZoomBotAdapter(BotAdapter):
         
         if not self.recording_permission_granted:
             return
+
+        if not self.video_input_manager:
+            return
         
         print("set_video_input_manager_based_on_state self.active_speaker_id =", self.active_speaker_id, "self.active_sharer_id =", self.active_sharer_id, "self.active_sharer_source_id =", self.active_sharer_source_id)
         if self.active_sharer_id:

--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -54,7 +54,10 @@ def parse_join_url(join_url):
 
 class ZoomBotAdapter(BotAdapter):
 
-    def __init__(self, *, display_name, send_message_callback, add_audio_chunk_callback, zoom_client_id, zoom_client_secret, meeting_url, add_video_frame_callback, wants_any_video_frames_callback, add_mixed_audio_chunk_callback):
+    def __init__(self, *, use_one_way_audio, use_mixed_audio, use_video, display_name, send_message_callback, add_audio_chunk_callback, zoom_client_id, zoom_client_secret, meeting_url, add_video_frame_callback, wants_any_video_frames_callback, add_mixed_audio_chunk_callback):
+        self.use_one_way_audio = use_one_way_audio
+        self.use_mixed_audio = use_mixed_audio
+        self.use_video = use_video
         self.display_name = display_name
         self.send_message_callback = send_message_callback
         self.add_audio_chunk_callback = add_audio_chunk_callback
@@ -100,7 +103,14 @@ class ZoomBotAdapter(BotAdapter):
         self.video_source_helper = None
         self.video_frame_size = (1920, 1080)
 
-        self.video_input_manager = VideoInputManager(new_frame_callback=self.add_video_frame_callback, wants_any_frames_callback=self.wants_any_video_frames_callback, video_frame_size=self.video_frame_size)
+        if self.use_video:
+            self.video_input_manager = VideoInputManager(
+                new_frame_callback=self.add_video_frame_callback, 
+                wants_any_frames_callback=self.wants_any_video_frames_callback, 
+                video_frame_size=self.video_frame_size
+            )
+        else:
+            self.video_input_manager = None
 
         self.meeting_sharing_controller = None
         self.meeting_share_ctrl_event = None
@@ -398,8 +408,8 @@ class ZoomBotAdapter(BotAdapter):
         if self.audio_source is None:
             self.audio_source = zoom.ZoomSDKAudioRawDataDelegateCallbacks(
                 collectPerformanceData=True, 
-                onOneWayAudioRawDataReceivedCallback=self.on_one_way_audio_raw_data_received_callback,
-                onMixedAudioRawDataReceivedCallback=self.add_mixed_audio_chunk_convert_to_bytes
+                onOneWayAudioRawDataReceivedCallback=self.on_one_way_audio_raw_data_received_callback if self.use_one_way_audio else None,
+                onMixedAudioRawDataReceivedCallback=self.add_mixed_audio_chunk_convert_to_bytes if self.use_mixed_audio else None
             )
 
         audio_helper_subscribe_result = self.audio_helper.subscribe(self.audio_source, False)


### PR DESCRIPTION
Adds a basic way to configure the bot's media processing pipeline. The main use case is to allow for a voice agent configuration which will not use mixed audio or video, and consume far less CPU resources.