### PR TITLE
Improve API error messages

### DIFF
--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -345,7 +345,7 @@ class OutputAudioView(APIView):
                 # Create or get existing MediaBlob
                 media_blob = MediaBlob.get_or_create_from_blob(project=request.auth.project, blob=audio_data, content_type=content_type)
             except Exception as e:
-                return Response({"error": f"Error creating the audio blob. Are you sure it's a valid {content_type}? {e}"}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({"error": f"Error creating the audio blob. Are you sure it's a valid {content_type} file?", "raw_error": str(e).split('\n')[0]}, status=status.HTTP_400_BAD_REQUEST)
 
             # Create BotMediaRequest
             BotMediaRequest.objects.create(
@@ -439,8 +439,11 @@ class OutputImageView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            # Create or get existing MediaBlob
-            media_blob = MediaBlob.get_or_create_from_blob(project=request.auth.project, blob=image_data, content_type=content_type)
+            try:
+                # Create or get existing MediaBlob
+                media_blob = MediaBlob.get_or_create_from_blob(project=request.auth.project, blob=image_data, content_type=content_type)
+            except Exception as e:
+                return Response({"error": f"Error creating the image blob. Are you sure it's a valid {content_type} file?", "debug_message": str(e).split('\n')[0]}, status=status.HTTP_400_BAD_REQUEST)
 
             # Create BotMediaRequest
             BotMediaRequest.objects.create(

--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -1,5 +1,6 @@
 import json
 import os
+import logging
 
 import redis
 from django.urls import reverse
@@ -345,6 +346,9 @@ class OutputAudioView(APIView):
                 # Create or get existing MediaBlob
                 media_blob = MediaBlob.get_or_create_from_blob(project=request.auth.project, blob=audio_data, content_type=content_type)
             except Exception as e:
+                logging.error(
+                    f"Error creating audio blob: {str(e).split('\n')[0]} (content_type={content_type}, bot_id={object_id})"
+                )
                 return Response({"error": f"Error creating the audio blob. Are you sure it's a valid {content_type} file?", "raw_error": str(e).split('\n')[0]}, status=status.HTTP_400_BAD_REQUEST)
 
             # Create BotMediaRequest
@@ -443,6 +447,9 @@ class OutputImageView(APIView):
                 # Create or get existing MediaBlob
                 media_blob = MediaBlob.get_or_create_from_blob(project=request.auth.project, blob=image_data, content_type=content_type)
             except Exception as e:
+                logging.error(
+                    f"Error creating image blob: {str(e).split('\n')[0]} (content_type={content_type}, bot_id={object_id})"
+                )
                 return Response({"error": f"Error creating the image blob. Are you sure it's a valid {content_type} file?", "debug_message": str(e).split('\n')[0]}, status=status.HTTP_400_BAD_REQUEST)
 
             # Create BotMediaRequest
@@ -499,6 +506,7 @@ class BotLeaveView(APIView):
 
             return Response(BotSerializer(bot).data, status=status.HTTP_200_OK)
         except ValidationError as e:
+            logging.error(f"Error leaving meeting: {str(e)} (bot_id={object_id})")
             return Response({"error": e.messages[0]}, status=status.HTTP_400_BAD_REQUEST)
         except Bot.DoesNotExist:
             return Response({"error": "Bot not found"}, status=status.HTTP_404_NOT_FOUND)

--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -346,10 +346,11 @@ class OutputAudioView(APIView):
                 # Create or get existing MediaBlob
                 media_blob = MediaBlob.get_or_create_from_blob(project=request.auth.project, blob=audio_data, content_type=content_type)
             except Exception as e:
+                error_message_first_line = str(e).split('\n')[0]
                 logging.error(
-                    f"Error creating audio blob: {str(e).split('\n')[0]} (content_type={content_type}, bot_id={object_id})"
+                    f"Error creating audio blob: {error_message_first_line} (content_type={content_type}, bot_id={object_id})"
                 )
-                return Response({"error": f"Error creating the audio blob. Are you sure it's a valid {content_type} file?", "raw_error": str(e).split('\n')[0]}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({"error": f"Error creating the audio blob. Are you sure it's a valid {content_type} file?", "raw_error": error_message_first_line}, status=status.HTTP_400_BAD_REQUEST)
 
             # Create BotMediaRequest
             BotMediaRequest.objects.create(
@@ -447,10 +448,11 @@ class OutputImageView(APIView):
                 # Create or get existing MediaBlob
                 media_blob = MediaBlob.get_or_create_from_blob(project=request.auth.project, blob=image_data, content_type=content_type)
             except Exception as e:
+                error_message_first_line = str(e).split('\n')[0]
                 logging.error(
-                    f"Error creating image blob: {str(e).split('\n')[0]} (content_type={content_type}, bot_id={object_id})"
+                    f"Error creating image blob: {error_message_first_line} (content_type={content_type}, bot_id={object_id})"
                 )
-                return Response({"error": f"Error creating the image blob. Are you sure it's a valid {content_type} file?", "debug_message": str(e).split('\n')[0]}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({"error": f"Error creating the image blob. Are you sure it's a valid {content_type} file?", "debug_message": error_message_first_line}, status=status.HTTP_400_BAD_REQUEST)
 
             # Create BotMediaRequest
             BotMediaRequest.objects.create(

--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -237,7 +237,7 @@ class SpeechView(APIView):
         # Check if bot is in a state that can play media
         if not BotEventManager.is_state_that_can_play_media(bot.state):
             return Response(
-                {"error": f"Bot is in state {BotStates(bot.state).label} and cannot play media"},
+                {"error": f"Bot is in state {BotStates.state_to_api_code(bot.state)} and cannot play media"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -337,12 +337,15 @@ class OutputAudioView(APIView):
             bot = Bot.objects.get(object_id=object_id, project=request.auth.project)
             if not BotEventManager.is_state_that_can_play_media(bot.state):
                 return Response(
-                    {"error": "Bot is not in a state that can play media"},
+                    {"error": f"Bot is in state {BotStates.state_to_api_code(bot.state)} and cannot play media"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            # Create or get existing MediaBlob
-            media_blob = MediaBlob.get_or_create_from_blob(project=request.auth.project, blob=audio_data, content_type=content_type)
+            try:
+                # Create or get existing MediaBlob
+                media_blob = MediaBlob.get_or_create_from_blob(project=request.auth.project, blob=audio_data, content_type=content_type)
+            except Exception as e:
+                return Response({"error": f"Error creating the audio blob. Are you sure it's a valid {content_type}? {e}"}, status=status.HTTP_400_BAD_REQUEST)
 
             # Create BotMediaRequest
             BotMediaRequest.objects.create(
@@ -432,7 +435,7 @@ class OutputImageView(APIView):
             bot = Bot.objects.get(object_id=object_id, project=request.auth.project)
             if not BotEventManager.is_state_that_can_play_media(bot.state):
                 return Response(
-                    {"error": "Bot is not in a state that can play media"},
+                    {"error": f"Bot is in state {BotStates.state_to_api_code(bot.state)} and cannot play media"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 

--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -38,6 +38,7 @@ from .serializers import (
     TranscriptUtteranceSerializer,
 )
 from .tasks import run_bot
+from django.core.exceptions import ValidationError
 
 TokenHeaderParameter = [
     OpenApiParameter(
@@ -467,6 +468,7 @@ class BotLeaveView(APIView):
                 description="Successfully requested to leave meeting",
                 examples=[LeavingBotExample],
             ),
+            400: OpenApiResponse(description="Bot is not in a valid state to leave the meeting"),
             404: OpenApiResponse(description="Bot not found"),
         },
         parameters=[
@@ -490,7 +492,8 @@ class BotLeaveView(APIView):
             send_sync_command(bot)
 
             return Response(BotSerializer(bot).data, status=status.HTTP_200_OK)
-
+        except ValidationError as e:
+            return Response({"error": e.messages[0]}, status=status.HTTP_400_BAD_REQUEST)
         except Bot.DoesNotExist:
             return Response({"error": "Bot not found"}, status=status.HTTP_404_NOT_FOUND)
 

--- a/bots/models.py
+++ b/bots/models.py
@@ -794,6 +794,9 @@ class MediaBlob(models.Model):
             random_string = "".join(random.choices(string.ascii_letters + string.digits, k=16))
             self.object_id = f"{self.OBJECT_ID_PREFIX}{random_string}"
 
+        if len(self.blob) > 10485760:
+            raise ValueError("blob exceeds 10MB limit")
+
         # Calculate checksum if this is a new object
         if not self.checksum:
             self.checksum = hashlib.sha256(self.blob).hexdigest()


### PR DESCRIPTION
Adds error message for when leave endpoint has called, but bot cannot leave (because the meeting already ended most likely).

Adds error message for the /output_audio and /output_image endpoints for when something is wrong with the raw audio or raw image we trying to get the bot to output.

Adds length limit to sent audio or image