### PR TITLE
Use webm as default recording format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     name: Run test suite
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: lint
 
     # Add service containers
     services:
@@ -76,6 +75,7 @@ jobs:
   lint:
     name: Run linting
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,6 @@ on:
     branches: [ main ]
 
 jobs:
-  lint:
-    name: Run linting
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Run Ruff
-        run: |
-          ruff check .
-          ruff format --check .
-
   test:
     name: Run test suite
     runs-on: ubuntu-latest
@@ -90,3 +72,21 @@ jobs:
           -e REDIS_URL \
           -e DJANGO_SETTINGS_MODULE \
           attendee-test:latest bash -c "python init_env.py > .env && python manage.py test --keepdb bots.tests"
+
+  lint:
+    name: Run linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Ruff
+        run: |
+          ruff check .
+          ruff format --check .

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -22,6 +22,7 @@ from bots.models import (
     Credentials,
     Participant,
     Recording,
+    RecordingFormats,
     RecordingManager,
     RecordingStates,
     Utterance,
@@ -127,7 +128,7 @@ class BotController:
 
     def get_recording_filename(self):
         recording = Recording.objects.get(bot=self.bot_in_db, is_default_recording=True)
-        return f"{hashlib.md5(recording.object_id.encode()).hexdigest()}.webm"
+        return f"{hashlib.md5(recording.object_id.encode()).hexdigest()}.{self.bot_in_db.recording_format()}"
 
     def on_rtmp_connection_failed(self):
         print("RTMP connection failed")
@@ -228,7 +229,11 @@ class BotController:
             get_participant_callback=self.get_participant,
         )
 
-        gstreamer_output_format = GstreamerPipeline.OUTPUT_FORMAT_WEBM
+        if self.bot_in_db.recording_format() == RecordingFormats.WEBM:
+            gstreamer_output_format = GstreamerPipeline.OUTPUT_FORMAT_WEBM
+        else:
+            gstreamer_output_format = GstreamerPipeline.OUTPUT_FORMAT_MP4
+
         self.rtmp_client = None
         if self.pipeline_configuration.rtmp_stream_audio or self.pipeline_configuration.rtmp_stream_video:
             gstreamer_output_format = GstreamerPipeline.OUTPUT_FORMAT_FLV

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -127,7 +127,7 @@ class BotController:
 
     def get_recording_filename(self):
         recording = Recording.objects.get(bot=self.bot_in_db, is_default_recording=True)
-        return f"{hashlib.md5(recording.object_id.encode()).hexdigest()}.mp4"
+        return f"{hashlib.md5(recording.object_id.encode()).hexdigest()}.webm"
 
     def on_rtmp_connection_failed(self):
         print("RTMP connection failed")
@@ -228,7 +228,7 @@ class BotController:
             get_participant_callback=self.get_participant,
         )
 
-        gstreamer_output_format = GstreamerPipeline.OUTPUT_FORMAT_MP4
+        gstreamer_output_format = GstreamerPipeline.OUTPUT_FORMAT_WEBM
         self.rtmp_client = None
         if self.pipeline_configuration.rtmp_stream_audio or self.pipeline_configuration.rtmp_stream_video:
             gstreamer_output_format = GstreamerPipeline.OUTPUT_FORMAT_FLV

--- a/bots/bot_controller/gstreamer_pipeline.py
+++ b/bots/bot_controller/gstreamer_pipeline.py
@@ -11,6 +11,7 @@ class GstreamerPipeline:
     AUDIO_FORMAT_FLOAT = "audio/x-raw,format=F32LE,channels=1,rate=48000,layout=interleaved"
     OUTPUT_FORMAT_FLV = "flv"
     OUTPUT_FORMAT_MP4 = "mp4"
+    OUTPUT_FORMAT_WEBM = "webm"
 
     def __init__(self, *, on_new_sample_callback, video_frame_size, audio_format, output_format, num_audio_sources):
         self.on_new_sample_callback = on_new_sample_callback
@@ -53,6 +54,8 @@ class GstreamerPipeline:
             muxer_string = "mp4mux name=muxer"
         elif self.output_format == self.OUTPUT_FORMAT_FLV:
             muxer_string = "h264parse ! flvmux name=muxer streamable=true"
+        elif self.output_format == self.OUTPUT_FORMAT_WEBM:
+            muxer_string = "h264parse ! matroskamux name=muxer streamable=true"
         else:
             raise ValueError(f"Invalid output format: {self.output_format}")
 

--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -183,9 +183,11 @@ class BotCreateView(APIView):
         bot_name = serializer.validated_data["bot_name"]
         transcription_settings = serializer.validated_data["transcription_settings"]
         rtmp_settings = serializer.validated_data["rtmp_settings"]
+        recording_settings = serializer.validated_data["recording_settings"]
         settings = {
             "transcription_settings": transcription_settings,
             "rtmp_settings": rtmp_settings,
+            "recording_settings": recording_settings,
         }
         bot = Bot.objects.create(
             project=project,

--- a/bots/models.py
+++ b/bots/models.py
@@ -101,6 +101,9 @@ class BotStates(models.IntegerChoices):
         }
         return mapping.get(value)
 
+class RecordingFormats(models.IntegerChoices):
+    MP4 = 1, "mp4"
+    WEBM = 2, "webm"
 
 class Bot(models.Model):
     OBJECT_ID_PREFIX = "bot_"
@@ -139,6 +142,12 @@ class Bot(models.Model):
             return None
 
         return f"{destination_url}/{stream_key}"
+
+    def recording_format(self):
+        recording_settings = self.settings.get("recording_settings", {})
+        if recording_settings is None:
+            recording_settings = {}
+        return recording_settings.get("format", RecordingFormats.WEBM)
 
     def last_bot_event(self):
         return self.bot_events.order_by("-created_at").first()

--- a/bots/models.py
+++ b/bots/models.py
@@ -101,9 +101,11 @@ class BotStates(models.IntegerChoices):
         }
         return mapping.get(value)
 
+
 class RecordingFormats(models.TextChoices):
     MP4 = "mp4"
     WEBM = "webm"
+
 
 class Bot(models.Model):
     OBJECT_ID_PREFIX = "bot_"

--- a/bots/models.py
+++ b/bots/models.py
@@ -101,9 +101,9 @@ class BotStates(models.IntegerChoices):
         }
         return mapping.get(value)
 
-class RecordingFormats(models.IntegerChoices):
-    MP4 = 1, "mp4"
-    WEBM = 2, "webm"
+class RecordingFormats(models.TextChoices):
+    MP4 = "mp4"
+    WEBM = "webm"
 
 class Bot(models.Model):
     OBJECT_ID_PREFIX = "bot_"

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -12,6 +12,7 @@ from .models import (
     BotEventTypes,
     BotStates,
     Recording,
+    RecordingFormats,
     RecordingStates,
     RecordingTranscriptionStates,
 )

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -69,7 +69,7 @@ class RTMPSettingsJSONField(serializers.JSONField):
         "properties": {
             "format": {
                 "type": "string",
-                "description": "The settings for the bot's recording",
+                "description": "The format of the recording to save. The supported formats are 'webm' and 'mp4'.",
             },
         },
         "required": ["format"],

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -62,6 +62,7 @@ class TranscriptionSettingsJSONField(serializers.JSONField):
 class RTMPSettingsJSONField(serializers.JSONField):
     pass
 
+
 @extend_schema_field(
     {
         "type": "object",
@@ -76,6 +77,7 @@ class RTMPSettingsJSONField(serializers.JSONField):
 )
 class RecordingSettingsJSONField(serializers.JSONField):
     pass
+
 
 @extend_schema_serializer(
     examples=[

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -69,7 +69,7 @@ class RTMPSettingsJSONField(serializers.JSONField):
         "properties": {
             "format": {
                 "type": "string",
-                "description": "The format of the recording to save",
+                "description": "The settings for the bot's recording",
             },
         },
         "required": ["format"],
@@ -166,7 +166,7 @@ class CreateBotSerializer(serializers.Serializer):
         return value
 
     recording_settings = RecordingSettingsJSONField(
-        help_text="The format of the recording to save, e.g. {'format': 'webm'} or {'format': 'mp4'}.",
+        help_text="The settings for the bot's recording. Either {'format': 'webm'} or {'format': 'mp4'}.",
         required=False,
         default={"format": RecordingFormats.WEBM},
     )

--- a/bots/templates/projects/project_bot_detail.html
+++ b/bots/templates/projects/project_bot_detail.html
@@ -155,7 +155,7 @@
                                     {% endfor %}
                                 </div>
                                 <div class="video-column">
-                                    <video width="100%" controls id="recording-video">
+                                    <video preload="auto" width="100%" controls id="recording-video">
                                         <source src="{{ recording.url }}">
                                         Your browser does not support the video tag.
                                     </video>

--- a/bots/templates/projects/project_bot_detail.html
+++ b/bots/templates/projects/project_bot_detail.html
@@ -156,7 +156,7 @@
                                 </div>
                                 <div class="video-column">
                                     <video width="100%" controls id="recording-video">
-                                        <source src="{{ recording.url }}" type="video/mp4">
+                                        <source src="{{ recording.url }}">
                                         Your browser does not support the video tag.
                                     </video>
                                 </div>

--- a/bots/tests/test_zoom_bot.py
+++ b/bots/tests/test_zoom_bot.py
@@ -28,6 +28,7 @@ from bots.models import (
     Organization,
     Project,
     Recording,
+    RecordingFormats,
     RecordingStates,
     RecordingTranscriptionStates,
     RecordingTypes,
@@ -662,6 +663,13 @@ class TestZoomBot(TransactionTestCase):
         mock_zoom_sdk_adapter,
         mock_zoom_sdk_video,
     ):
+        self.bot.settings = {
+            "recording_settings": {
+                "format": RecordingFormats.MP4,
+            }
+        }
+        self.bot.save()
+
         # Set up Google TTS mock
         mock_tts_client = MagicMock()
         mock_tts_response = MagicMock()
@@ -959,6 +967,13 @@ class TestZoomBot(TransactionTestCase):
         mock_zoom_sdk_adapter,
         mock_zoom_sdk_video,
     ):
+        self.bot.settings = {
+            "recording_settings": {
+                "format": RecordingFormats.MP4,
+            }
+        }
+        self.bot.save()
+
         # Set up Deepgram mock
         MockDeepgramClient.return_value = create_mock_deepgram()
 

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -177,6 +177,65 @@ paths:
                   summary: Leaving Bot
                   description: Example response when requesting a bot to leave
           description: Successfully requested to leave meeting
+        '400':
+          description: Bot is not in a valid state to leave the meeting
+        '404':
+          description: Bot not found
+  /api/v1/bots/{object_id}/speech:
+    post:
+      operationId: Output speech
+      description: Causes the bot to speak a message in the meeting.
+      summary: Output speech
+      parameters:
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          default: Token YOUR_API_KEY_HERE
+        description: API key for authentication
+        required: true
+      - in: header
+        name: Content-Type
+        schema:
+          type: string
+          default: application/json
+        description: Should always be application/json
+        required: true
+      - in: path
+        name: object_id
+        schema:
+          type: string
+        description: Bot ID
+        required: true
+        examples:
+          BotIDExample:
+            value: bot_xxxxxxxxxxx
+            summary: Bot ID Example
+      tags:
+      - Bots
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpeechRequest'
+            examples:
+              ValidSpeechRequest:
+                value:
+                  text: Hello, this is a bot speaking text.
+                  text_to_speech_settings:
+                    google:
+                      voice_language_code: en-US
+                      voice_name: en-US-Casual-K
+                summary: Valid speech request
+                description: Example of a valid speech request
+        required: true
+      security:
+      - {}
+      responses:
+        '200':
+          description: Speech request created successfully
+        '400':
+          description: Invalid input
         '404':
           description: Bot not found
   /api/v1/bots/{object_id}/output_audio:
@@ -342,63 +401,6 @@ paths:
                     start_timestamp_ms: 1733114771000
                   summary: Recording Upload
           description: Short-lived S3 URL for the recording
-  /api/v1/bots/{object_id}/speech:
-    post:
-      operationId: Output speech
-      description: Causes the bot to speak a message in the meeting.
-      summary: Output speech
-      parameters:
-      - in: header
-        name: Authorization
-        schema:
-          type: string
-          default: Token YOUR_API_KEY_HERE
-        description: API key for authentication
-        required: true
-      - in: header
-        name: Content-Type
-        schema:
-          type: string
-          default: application/json
-        description: Should always be application/json
-        required: true
-      - in: path
-        name: object_id
-        schema:
-          type: string
-        description: Bot ID
-        required: true
-        examples:
-          BotIDExample:
-            value: bot_xxxxxxxxxxx
-            summary: Bot ID Example
-      tags:
-      - Bots
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SpeechRequest'
-            examples:
-              ValidSpeechRequest:
-                value:
-                  text: Hello, this is a bot speaking text.
-                  text_to_speech_settings:
-                    google:
-                      voice_language_code: en-US
-                      voice_name: en-US-Casual-K
-                summary: Valid speech request
-                description: Example of a valid speech request
-        required: true
-      security:
-      - {}
-      responses:
-        '200':
-          description: Speech request created successfully
-        '400':
-          description: Invalid input
-        '404':
-          description: Bot not found
   /api/v1/bots/{object_id}/transcript:
     get:
       operationId: Get Bot Transcript
@@ -533,6 +535,19 @@ components:
           - stream_key
           description: 'RTMP server to stream to, e.g. {''destination_url'': ''rtmp://global-live.mux.com:5222/app'',
             ''stream_key'': ''xxxx''}.'
+        recording_settings:
+          type: object
+          properties:
+            format:
+              type: string
+              description: The format of the recording to save. The supported formats
+                are 'webm' and 'mp4'.
+          required:
+          - format
+          default:
+            format: webm
+          description: 'The settings for the bot''s recording. Either {''format'':
+            ''webm''} or {''format'': ''mp4''}.'
       required:
       - bot_name
       - meeting_url


### PR DESCRIPTION
Currently the mp4 recording files we generate are not suitable for streaming, because they have the MOOV atom at the end. This is because we are generating the mp4 file bit by bit using GStreamer.

We could reprocess the entire mp4 file after it is generated to put the MOOV atom at the start, which makes it suitable for streaming, but this is an expensive operation.

Instead, we'll switch the default video output format to webm, a format which is suitable for streaming. You can still generate mp4 by passing an argument to the API.

Closes #86 