### PR TITLE
Load video duration at start in bot detail page

### DIFF
--- a/bots/templates/projects/project_bot_detail.html
+++ b/bots/templates/projects/project_bot_detail.html
@@ -73,6 +73,16 @@
     .bold {
         font-weight: bold;
     }
+    /* Make time display always visible */
+    .video-js .vjs-time-control {
+        display: block !important;
+    }
+    .video-js .vjs-current-time,
+    .video-js .vjs-duration,
+    .video-js .vjs-time-divider {
+        display: block !important;
+        padding: 0 0.3em;
+    }
 </style>
 
 <div class="container mt-4">
@@ -163,6 +173,7 @@
                                         width="640"
                                         height="360"
                                         data-duration-seconds="{{ recording.duration_seconds }}"
+                                        disablePictureInPicture
                                     >
                                         <source src="{{ recording.url }}">
                                         <p class="vjs-no-js">
@@ -244,7 +255,13 @@
     // Then initialize the player and store it in a window variable
     window.player = videojs('recording-video', {
         responsive: true,
-        fluid: true
+        fluid: true,
+        controlBar: {
+            remainingTimeDisplay: false,
+            currentTimeDisplay: true,
+            timeDivider: true,
+            durationDisplay: true
+        }
     });
 
     window.player.ready(function() {      

--- a/bots/templates/projects/project_bot_detail.html
+++ b/bots/templates/projects/project_bot_detail.html
@@ -162,6 +162,7 @@
                                     preload="auto"
                                     width="640"
                                     height="360"
+                                    data-duration-seconds="{{ recording.duration_seconds }}"
                                     data-setup='{"html5": {"nativeTextTracks": false}}'>
                                     <source src="{{ recording.url }}">
                                     <p class="vjs-no-js">
@@ -236,9 +237,6 @@
 <link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video-js.min.css" rel="stylesheet">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video.min.js"></script>
 
-<!-- Optional: Include HLS support for broader compatibility -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-contrib-hls/5.15.0/videojs-contrib-hls.min.js"></script>
-
 <script>
     
     var player = videojs('recording-video', {
@@ -255,6 +253,9 @@
 
     player.ready(function() {
       console.log('Player is ready');
+        const recordingDurationSeconds = player.el().dataset.durationSeconds;
+        console.log('Recording duration seconds:', recordingDurationSeconds);
+        player.duration(recordingDurationSeconds);
       
       // Optional: Monitor buffering and loading
       player.on('waiting', function() {
@@ -263,12 +264,17 @@
       
       player.on('canplay', function() {
         console.log('Video can be played');
+        const recordingDurationSeconds = player.el().dataset.durationSeconds;
+        console.log('Recording duration seconds:', recordingDurationSeconds);
+        player.duration(recordingDurationSeconds);
       });
       
       // Error handling
       player.on('error', function(e) {
         console.error('Video player error:', player.error());
       });
+
+
     });
 
     function seekVideo(element, timestamp_ms) {

--- a/bots/templates/projects/project_bot_detail.html
+++ b/bots/templates/projects/project_bot_detail.html
@@ -245,33 +245,34 @@
     </div>
 </div>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video-js.min.css" rel="stylesheet">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video.min.js"></script>
 <script>
-    // First, check if player already exists and dispose it
-    if (window.player) {
-        window.player.dispose();
+    function initializePlayer() {
+        // First, check if player already exists and dispose it
+        if (window.player) {
+            window.player.dispose();
+        }
+
+        // Then initialize the player and store it in a window variable
+        window.player = videojs('recording-video', {
+            responsive: true,
+            fluid: true,
+            controlBar: {
+                remainingTimeDisplay: false,
+                currentTimeDisplay: true,
+                timeDivider: true,
+                durationDisplay: true
+            }
+        });
+
+        window.player.ready(function() {      
+        window.player.on('canplay', function() {
+            const recordingDurationSeconds = window.player.el().dataset.durationSeconds;
+            if (recordingDurationSeconds) {
+                window.player.duration(recordingDurationSeconds);
+            }
+        });
+        });
     }
-
-    // Then initialize the player and store it in a window variable
-    window.player = videojs('recording-video', {
-        responsive: true,
-        fluid: true,
-        controlBar: {
-            remainingTimeDisplay: false,
-            currentTimeDisplay: true,
-            timeDivider: true,
-            durationDisplay: true
-        }
-    });
-
-    window.player.ready(function() {      
-      window.player.on('canplay', function() {
-        const recordingDurationSeconds = window.player.el().dataset.durationSeconds;
-        if (recordingDurationSeconds) {
-            window.player.duration(recordingDurationSeconds);
-        }
-      });
-    });
 
     function seekVideo(element, timestamp_ms) {
         const container = element.closest('.recording-container');
@@ -347,4 +348,5 @@
         });
     });
 </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video.min.js" onload="initializePlayer()"></script>
 {% endblock %}

--- a/bots/templates/projects/project_bot_detail.html
+++ b/bots/templates/projects/project_bot_detail.html
@@ -156,21 +156,20 @@
                                 </div>
                                 <div class="video-column">
                                     <video 
-                                    id="recording-video"
-                                    class="video-js vjs-default-skin vjs-big-play-button vjs-fluid"
-                                    controls
-                                    preload="auto"
-                                    width="640"
-                                    height="360"
-                                    data-duration-seconds="{{ recording.duration_seconds }}"
-                                    data-setup='{"html5": {"nativeTextTracks": false}}'>
-                                    <source src="{{ recording.url }}">
-                                    <p class="vjs-no-js">
-                                      To view this video please enable JavaScript, and consider upgrading to a
-                                      web browser that supports HTML5 video
-                                    </p>
-                                  </video>
-
+                                        id="recording-video"
+                                        class="video-js vjs-default-skin vjs-fluid"
+                                        controls
+                                        preload="auto"
+                                        width="640"
+                                        height="360"
+                                        data-duration-seconds="{{ recording.duration_seconds }}"
+                                    >
+                                        <source src="{{ recording.url }}">
+                                        <p class="vjs-no-js">
+                                            To view this video please enable JavaScript, and consider upgrading to a
+                                            web browser that supports HTML5 video
+                                        </p>
+                                    </video>
                                 </div>
                             </div>
                         {% else %}
@@ -236,45 +235,25 @@
 </div>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video-js.min.css" rel="stylesheet">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video.min.js"></script>
-
 <script>
-    
-    var player = videojs('recording-video', {
-      responsive: true,
-      fluid: true,
-      html5: {
-        hls: {
-          overrideNative: true
-        },
-        nativeAudioTracks: false,
-        nativeVideoTracks: false
-      }
+    // First, check if player already exists and dispose it
+    if (window.player) {
+        window.player.dispose();
+    }
+
+    // Then initialize the player and store it in a window variable
+    window.player = videojs('recording-video', {
+        responsive: true,
+        fluid: true
     });
 
-    player.ready(function() {
-      console.log('Player is ready');
-        const recordingDurationSeconds = player.el().dataset.durationSeconds;
-        console.log('Recording duration seconds:', recordingDurationSeconds);
-        player.duration(recordingDurationSeconds);
-      
-      // Optional: Monitor buffering and loading
-      player.on('waiting', function() {
-        console.log('Video is buffering');
+    window.player.ready(function() {      
+      window.player.on('canplay', function() {
+        const recordingDurationSeconds = window.player.el().dataset.durationSeconds;
+        if (recordingDurationSeconds) {
+            window.player.duration(recordingDurationSeconds);
+        }
       });
-      
-      player.on('canplay', function() {
-        console.log('Video can be played');
-        const recordingDurationSeconds = player.el().dataset.durationSeconds;
-        console.log('Recording duration seconds:', recordingDurationSeconds);
-        player.duration(recordingDurationSeconds);
-      });
-      
-      // Error handling
-      player.on('error', function(e) {
-        console.error('Video player error:', player.error());
-      });
-
-
     });
 
     function seekVideo(element, timestamp_ms) {

--- a/bots/templates/projects/project_bot_detail.html
+++ b/bots/templates/projects/project_bot_detail.html
@@ -155,10 +155,21 @@
                                     {% endfor %}
                                 </div>
                                 <div class="video-column">
-                                    <video preload="auto" width="100%" controls id="recording-video">
-                                        <source src="{{ recording.url }}">
-                                        Your browser does not support the video tag.
-                                    </video>
+                                    <video 
+                                    id="recording-video"
+                                    class="video-js vjs-default-skin vjs-big-play-button vjs-fluid"
+                                    controls
+                                    preload="auto"
+                                    width="640"
+                                    height="360"
+                                    data-setup='{"html5": {"nativeTextTracks": false}}'>
+                                    <source src="{{ recording.url }}">
+                                    <p class="vjs-no-js">
+                                      To view this video please enable JavaScript, and consider upgrading to a
+                                      web browser that supports HTML5 video
+                                    </p>
+                                  </video>
+
                                 </div>
                             </div>
                         {% else %}
@@ -222,7 +233,44 @@
         </div>
     </div>
 </div>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video-js.min.css" rel="stylesheet">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video.min.js"></script>
+
+<!-- Optional: Include HLS support for broader compatibility -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-contrib-hls/5.15.0/videojs-contrib-hls.min.js"></script>
+
 <script>
+    
+    var player = videojs('recording-video', {
+      responsive: true,
+      fluid: true,
+      html5: {
+        hls: {
+          overrideNative: true
+        },
+        nativeAudioTracks: false,
+        nativeVideoTracks: false
+      }
+    });
+
+    player.ready(function() {
+      console.log('Player is ready');
+      
+      // Optional: Monitor buffering and loading
+      player.on('waiting', function() {
+        console.log('Video is buffering');
+      });
+      
+      player.on('canplay', function() {
+        console.log('Video can be played');
+      });
+      
+      // Error handling
+      player.on('error', function(e) {
+        console.error('Video player error:', player.error());
+      });
+    });
+
     function seekVideo(element, timestamp_ms) {
         const container = element.closest('.recording-container');
         const video = container.querySelector('video');

--- a/bots/templates/projects/project_bot_detail.html
+++ b/bots/templates/projects/project_bot_detail.html
@@ -247,6 +247,15 @@
 <link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video-js.min.css" rel="stylesheet">
 <script>
     function initializePlayer() {
+        // Wait for the element to be available
+        const videoElement = document.getElementById('recording-video');
+        if (!videoElement) {
+            // If element is not ready, try again in 100ms
+            console.log('Video element not ready, trying again in 100ms');
+            setTimeout(initializePlayer, 100);
+            return;
+        }
+
         // First, check if player already exists and dispose it
         if (window.player) {
             window.player.dispose();
@@ -265,12 +274,12 @@
         });
 
         window.player.ready(function() {      
-        window.player.on('canplay', function() {
-            const recordingDurationSeconds = window.player.el().dataset.durationSeconds;
-            if (recordingDurationSeconds) {
-                window.player.duration(recordingDurationSeconds);
-            }
-        });
+            window.player.on('canplay', function() {
+                const recordingDurationSeconds = window.player.el().dataset.durationSeconds;
+                if (recordingDurationSeconds) {
+                    window.player.duration(recordingDurationSeconds);
+                }
+            });
         });
     }
 

--- a/bots/templates/projects/project_bot_detail.html
+++ b/bots/templates/projects/project_bot_detail.html
@@ -244,44 +244,32 @@
         </div>
     </div>
 </div>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video-js.min.css" rel="stylesheet">
 <script>
-    function initializePlayer() {
-        // Wait for the element to be available
-        const videoElement = document.getElementById('recording-video');
-        if (!videoElement) {
-            // If element is not ready, try again in 100ms
-            console.log('Video element not ready, trying again in 100ms');
-            setTimeout(initializePlayer, 100);
-            return;
-        }
+    // First, check if player already exists and dispose it
+    if (window.player) {
+        window.player.dispose();
+    }
 
-        // First, check if player already exists and dispose it
-        if (window.player) {
-            window.player.dispose();
+    // Then initialize the player and store it in a window variable
+    window.player = videojs('recording-video', {
+        responsive: true,
+        fluid: true,
+        controlBar: {
+            remainingTimeDisplay: false,
+            currentTimeDisplay: true,
+            timeDivider: true,
+            durationDisplay: true
         }
+    });
 
-        // Then initialize the player and store it in a window variable
-        window.player = videojs('recording-video', {
-            responsive: true,
-            fluid: true,
-            controlBar: {
-                remainingTimeDisplay: false,
-                currentTimeDisplay: true,
-                timeDivider: true,
-                durationDisplay: true
+    window.player.ready(function() {      
+        window.player.on('canplay', function() {
+            const recordingDurationSeconds = window.player.el().dataset.durationSeconds;
+            if (recordingDurationSeconds) {
+                window.player.duration(recordingDurationSeconds);
             }
         });
-
-        window.player.ready(function() {      
-            window.player.on('canplay', function() {
-                const recordingDurationSeconds = window.player.el().dataset.durationSeconds;
-                if (recordingDurationSeconds) {
-                    window.player.duration(recordingDurationSeconds);
-                }
-            });
-        });
-    }
+    });
 
     function seekVideo(element, timestamp_ms) {
         const container = element.closest('.recording-container');
@@ -357,5 +345,4 @@
         });
     });
 </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video.min.js" onload="initializePlayer()"></script>
 {% endblock %}

--- a/bots/templates/projects/sidebar.html
+++ b/bots/templates/projects/sidebar.html
@@ -79,7 +79,8 @@
     </div>
 </div>
 <script>
-    htmx.logAll();
+    // When we need to debug htmx
+    // htmx.logAll();
     function setActiveLink(element) {
         // Remove active class from all nav links
         document.querySelectorAll('.nav-link').forEach(link => {

--- a/bots/utils.py
+++ b/bots/utils.py
@@ -268,7 +268,7 @@ def generate_recordings_json_for_bot_detail_view(bot):
         if recording.started_at and recording.completed_at:
             duration_seconds = (recording.completed_at - recording.started_at).total_seconds()
         else:
-            duration_seconds = None
+            duration_seconds = ""
         recordings_data.append(
             {
                 "state": recording.state,

--- a/bots/utils.py
+++ b/bots/utils.py
@@ -265,10 +265,15 @@ def generate_recordings_json_for_bot_detail_view(bot):
     for recording in bot.recordings.all():
         if recording.state != RecordingStates.COMPLETE:
             continue
+        if recording.started_at and recording.completed_at:
+            duration_seconds = (recording.completed_at - recording.started_at).total_seconds()
+        else:
+            duration_seconds = None
         recordings_data.append(
             {
                 "state": recording.state,
                 "url": recording.url,
+                "duration_seconds": duration_seconds,
                 "utterances": generate_utterance_json_for_bot_detail_view(recording),
             }
         )

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,9 +7,12 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video-js.min.css">
+
     <!-- HTMX -->
     <!--  <script src="https://unpkg.com/htmx.org@2.0.3"></script>  -->
     <script src="https://unpkg.com/htmx.org@2.0.3/dist/htmx.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.20.3/video.min.js"></script>
 
     <style>
         .sidebar {


### PR DESCRIPTION
The videos now stream immediately, but we can't see their duration. This PR uses videojs to improve the player experience in the bot detail page. You'll see the video duration immediately and be able to move through the timeline however you want.