### PR TITLE
updated deprecated call to utctime

### DIFF
--- a/bots/bot_controller/closed_caption_manager.py
+++ b/bots/bot_controller/closed_caption_manager.py
@@ -5,24 +5,25 @@ from typing import Dict, Optional
 class CaptionEntry:
     def __init__(self, caption_data: dict):
         self.caption_data = caption_data
-        self.created_at = datetime.utcnow()
+        self.created_at = datetime.now(datetime.UTC)
         self.modified_at = self.created_at
         self.last_upsert_to_db_at: Optional[datetime] = None
 
     def update(self, caption_data: dict):
         self.caption_data = caption_data
-        self.modified_at = datetime.utcnow()
+        self.modified_at = datetime.now(datetime.UTC)
 
     def should_upsert_to_db(self, should_flush=False) -> bool:
         # If never upserted to db, and it's been at least a few seconds since creation
         if not self.last_upsert_to_db_at:
-            return ((datetime.utcnow() - self.created_at) > timedelta(seconds=15)) or should_flush
+            return ((datetime.now(datetime.UTC) - self.created_at) > timedelta(seconds=15)) or should_flush
 
         # If modified since last upsert to db and hasn't been updated recently
-        return self.modified_at > self.last_upsert_to_db_at and (((datetime.utcnow() - self.modified_at) > timedelta(seconds=15)) or should_flush)
+        return (self.modified_at > self.last_upsert_to_db_at and 
+                ((datetime.now(datetime.UTC) - self.modified_at) > timedelta(seconds=15) or should_flush))
 
     def mark_upserted_to_db(self):
-        self.last_upsert_to_db_at = datetime.utcnow()
+        self.last_upsert_to_db_at = datetime.now(datetime.UTC)
 
 
 class ClosedCaptionManager:
@@ -73,5 +74,5 @@ class ClosedCaptionManager:
                     entry.mark_upserted_to_db()
 
                     # If this caption hasn't been modified in a while, remove it from memory
-                    if (datetime.utcnow() - entry.modified_at) > timedelta(seconds=60):
+                    if (datetime.now(datetime.UTC) - entry.modified_at) > timedelta(seconds=60):
                         del self.captions[key]

--- a/bots/bot_controller/individual_audio_input_manager.py
+++ b/bots/bot_controller/individual_audio_input_manager.py
@@ -38,14 +38,14 @@ class IndividualAudioInputManager:
             self.process_chunk(speaker_id, chunk_time, chunk_bytes)
 
         for speaker_id in list(self.first_nonsilent_audio_time.keys()):
-            self.process_chunk(speaker_id, datetime.utcnow(), None)
+            self.process_chunk(speaker_id, datetime.now(datetime.UTC), None)
 
     # When the meeting ends, we need to flush all utterances. Do this by pretending that we received a chunk of silence at the end of the meeting.
     def flush_utterances(self):
         for speaker_id in list(self.first_nonsilent_audio_time.keys()):
             self.process_chunk(
                 speaker_id,
-                datetime.utcnow() + timedelta(seconds=self.SILENCE_DURATION_LIMIT + 1),
+                datetime.now(datetime.UTC) + timedelta(seconds=self.SILENCE_DURATION_LIMIT + 1),
                 None,
             )
 

--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -20,7 +20,7 @@ from bots.bot_controller.automatic_leave_configuration import AutomaticLeaveConf
 
 
 def generate_jwt(client_id, client_secret):
-    iat = datetime.utcnow()
+    iat = datetime.now(datetime.UTC)
     exp = iat + timedelta(hours=24)
 
     payload = {
@@ -472,7 +472,7 @@ class ZoomBotAdapter(BotAdapter):
         if node_id == self.my_participant_id:
             return
 
-        current_time = datetime.utcnow()
+        current_time = datetime.now(datetime.UTC)
         self.last_audio_received_at = time.time()
         self.add_audio_chunk_callback(node_id, current_time, data.GetBuffer())
 


### PR DESCRIPTION

`datetime.utcnow()` has been deprecated.

See: https://docs.python.org/3/library/datetime.html#datetime.datetime.now

This PR updates the codebase accordingly.