### PR TITLE
Add bots to admin page

### DIFF
--- a/bots/admin.py
+++ b/bots/admin.py
@@ -1,1 +1,38 @@
-# Register your models here.
+from django.contrib import admin
+from .models import Bot
+
+@admin.register(Bot)
+class BotAdmin(admin.ModelAdmin):
+    actions = None
+    list_display = ('object_id', 'name', 'project', 'state', 'created_at', 'updated_at')
+    list_filter = ('state', 'project')
+    search_fields = ('object_id',)
+    readonly_fields = ('object_id', 'created_at', 'updated_at', 'state')
+    
+    def has_add_permission(self, request):
+        return False
+        
+    def has_change_permission(self, request, obj=None):
+        return False
+        
+    def has_delete_permission(self, request, obj=None):
+        return True
+    
+    # Optional: if you want to organize the fields in the detail view
+    fieldsets = (
+        ('Basic Information', {
+            'fields': ('object_id', 'name', 'project')
+        }),
+        ('Meeting Details', {
+            'fields': ('meeting_url', 'meeting_uuid')
+        }),
+        ('Status', {
+            'fields': ('state',)
+        }),
+        ('Settings', {
+            'fields': ('settings',)
+        }),
+        ('Metadata', {
+            'fields': ('created_at', 'updated_at', 'version')
+        }),
+    )

--- a/bots/admin.py
+++ b/bots/admin.py
@@ -1,38 +1,42 @@
+import os
+
 from django.contrib import admin
 from django.utils.html import format_html
+
 from .models import Bot, BotEvent
-import os
+
 
 # Create an inline for BotEvent to show on the Bot admin page
 class BotEventInline(admin.TabularInline):
     model = BotEvent
     extra = 0
-    readonly_fields = ('created_at', 'event_type', 'event_sub_type', 'old_state', 'new_state', 'metadata')
+    readonly_fields = ("created_at", "event_type", "event_sub_type", "old_state", "new_state", "metadata")
     can_delete = False
     max_num = 0  # Don't allow adding new events through admin
-    ordering = ('created_at',)  # Show most recent events first
-    
+    ordering = ("created_at",)  # Show most recent events first
+
     def has_add_permission(self, request, obj=None):
         return False
+
 
 @admin.register(Bot)
 class BotAdmin(admin.ModelAdmin):
     actions = None
-    list_display = ('object_id', 'name', 'project', 'state', 'created_at', 'updated_at', 'view_logs_link')
-    list_filter = ('state', 'project')
-    search_fields = ('object_id',)
-    readonly_fields = ('object_id', 'created_at', 'updated_at', 'state', 'view_logs_link')
+    list_display = ("object_id", "name", "project", "state", "created_at", "updated_at", "view_logs_link")
+    list_filter = ("state", "project")
+    search_fields = ("object_id",)
+    readonly_fields = ("object_id", "created_at", "updated_at", "state", "view_logs_link")
     inlines = [BotEventInline]  # Add the inline to the admin
-    
+
     def has_add_permission(self, request):
         return False
-        
+
     def has_change_permission(self, request, obj=None):
         return False
-        
+
     def has_delete_permission(self, request, obj=None):
         return True
-    
+
     def view_logs_link(self, obj):
         pod_name = obj.k8s_pod_name()
         link_formatting_str = os.getenv("CLOUD_LOGS_LINK_FORMATTING_STR")
@@ -41,26 +45,16 @@ class BotAdmin(admin.ModelAdmin):
         try:
             url = link_formatting_str.format(pod_name=pod_name)
             return format_html('<a href="{}" target="_blank">View Logs</a>', url)
-        except Exception as e:
+        except Exception:
             return None
-    
+
     view_logs_link.short_description = "Cloud Logs"
-    
+
     # Optional: if you want to organize the fields in the detail view
     fieldsets = (
-        ('Basic Information', {
-            'fields': ('object_id', 'name', 'project')
-        }),
-        ('Meeting Details', {
-            'fields': ('meeting_url', 'meeting_uuid')
-        }),
-        ('Status', {
-            'fields': ('state', 'view_logs_link')
-        }),
-        ('Settings', {
-            'fields': ('settings',)
-        }),
-        ('Metadata', {
-            'fields': ('created_at', 'updated_at', 'version')
-        }),
+        ("Basic Information", {"fields": ("object_id", "name", "project")}),
+        ("Meeting Details", {"fields": ("meeting_url", "meeting_uuid")}),
+        ("Status", {"fields": ("state", "view_logs_link")}),
+        ("Settings", {"fields": ("settings",)}),
+        ("Metadata", {"fields": ("created_at", "updated_at", "version")}),
     )

--- a/bots/admin.py
+++ b/bots/admin.py
@@ -1,13 +1,28 @@
 from django.contrib import admin
-from .models import Bot
+from django.utils.html import format_html
+from .models import Bot, BotEvent
+import os
+
+# Create an inline for BotEvent to show on the Bot admin page
+class BotEventInline(admin.TabularInline):
+    model = BotEvent
+    extra = 0
+    readonly_fields = ('created_at', 'event_type', 'event_sub_type', 'old_state', 'new_state', 'metadata')
+    can_delete = False
+    max_num = 0  # Don't allow adding new events through admin
+    ordering = ('created_at',)  # Show most recent events first
+    
+    def has_add_permission(self, request, obj=None):
+        return False
 
 @admin.register(Bot)
 class BotAdmin(admin.ModelAdmin):
     actions = None
-    list_display = ('object_id', 'name', 'project', 'state', 'created_at', 'updated_at')
+    list_display = ('object_id', 'name', 'project', 'state', 'created_at', 'updated_at', 'view_logs_link')
     list_filter = ('state', 'project')
     search_fields = ('object_id',)
-    readonly_fields = ('object_id', 'created_at', 'updated_at', 'state')
+    readonly_fields = ('object_id', 'created_at', 'updated_at', 'state', 'view_logs_link')
+    inlines = [BotEventInline]  # Add the inline to the admin
     
     def has_add_permission(self, request):
         return False
@@ -18,6 +33,19 @@ class BotAdmin(admin.ModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return True
     
+    def view_logs_link(self, obj):
+        pod_name = obj.k8s_pod_name()
+        link_formatting_str = os.getenv("CLOUD_LOGS_LINK_FORMATTING_STR")
+        if not link_formatting_str:
+            return None
+        try:
+            url = link_formatting_str.format(pod_name=pod_name)
+            return format_html('<a href="{}" target="_blank">View Logs</a>', url)
+        except Exception as e:
+            return None
+    
+    view_logs_link.short_description = "Cloud Logs"
+    
     # Optional: if you want to organize the fields in the detail view
     fieldsets = (
         ('Basic Information', {
@@ -27,7 +55,7 @@ class BotAdmin(admin.ModelAdmin):
             'fields': ('meeting_url', 'meeting_uuid')
         }),
         ('Status', {
-            'fields': ('state',)
+            'fields': ('state', 'view_logs_link')
         }),
         ('Settings', {
             'fields': ('settings',)

--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -127,7 +127,7 @@ def launch_bot(bot):
         from .bot_pod_creator import BotPodCreator
 
         bot_pod_creator = BotPodCreator()
-        bot_pod_creator.create_bot_pod(bot_id=bot.id, bot_name=f"bot-pod-{bot.object_id}".lower().replace("_", "-"))
+        bot_pod_creator.create_bot_pod(bot_id=bot.id, bot_name=bot.k8s_pod_name())
     else:
         # Default to launching bot via celery
         run_bot.delay(bot.id)

--- a/bots/models.py
+++ b/bots/models.py
@@ -172,6 +172,9 @@ class Bot(models.Model):
     def __str__(self):
         return f"{self.object_id} - {self.project.name} in {self.meeting_url}"
 
+    def k8s_pod_name(self):
+        return f"bot-pod-{self.id}-{self.object_id}".lower().replace("_", "-")
+
 
 class BotEventTypes(models.IntegerChoices):
     BOT_PUT_IN_WAITING_ROOM = 1, "Bot Put in Waiting Room"


### PR DESCRIPTION
Adds bots to the django admin screen. This will help alot with debugging in the cloud. No sensitive information is shown.