### PR TITLE
Use media recorder for gmeet recording

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ RUN apt-get update  \
 # Install Chrome dependencies
 RUN apt-get install -y xvfb x11-xkb-utils xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic x11-apps libvulkan1 fonts-liberation xdg-utils wget
 # Install a specific version of Chrome.
-RUN wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_133.0.6943.98-1_amd64.deb
-RUN apt-get install -y ./google-chrome-stable_133.0.6943.98-1_amd64.deb
+RUN wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_134.0.6998.88-1_amd64.deb
+RUN apt-get install -y ./google-chrome-stable_134.0.6998.88-1_amd64.deb
 
 # Install ALSA
 RUN apt-get update && apt-get install -y libasound2 libasound2-plugins alsa alsa-utils alsa-oss

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -39,6 +39,7 @@ from .file_uploader import FileUploader
 from .gstreamer_pipeline import GstreamerPipeline
 from .individual_audio_input_manager import IndividualAudioInputManager
 from .pipeline_configuration import PipelineConfiguration
+from .media_recorder_receiver import MediaRecorderReceiver
 from .rtmp_client import RTMPClient
 
 gi.require_version("GLib", "2.0")

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -38,8 +38,8 @@ from .closed_caption_manager import ClosedCaptionManager
 from .file_uploader import FileUploader
 from .gstreamer_pipeline import GstreamerPipeline
 from .individual_audio_input_manager import IndividualAudioInputManager
-from .pipeline_configuration import PipelineConfiguration
 from .media_recorder_receiver import MediaRecorderReceiver
+from .pipeline_configuration import PipelineConfiguration
 from .rtmp_client import RTMPClient
 
 gi.require_version("GLib", "2.0")

--- a/bots/bot_controller/media_recorder_receiver.py
+++ b/bots/bot_controller/media_recorder_receiver.py
@@ -21,9 +21,17 @@ class MediaRecorderReceiver:
         with open(self.file_location, mode) as f:
             f.write(chunk)
 
+    def get_seekable_path(self, path):
+        """
+        Transform a file path to include '.seekable' before the extension.
+        Example: /tmp/file.webm -> /tmp/file.seekable.webm
+        """
+        base, ext = os.path.splitext(path)
+        return f"{base}.seekable{ext}"
+
     def make_file_seekable(self):
         input_path = self.file_location
-        output_path = self.file_location.with_suffix(".seekable.mp4")
+        output_path = self.get_seekable_path(self.file_location)
         """Use ffmpeg to move the moov atom to the beginning of the file."""
         logger.info(f"Making file seekable: {input_path} -> {output_path}")
         # log how many bytes are in the file

--- a/bots/bot_controller/media_recorder_receiver.py
+++ b/bots/bot_controller/media_recorder_receiver.py
@@ -1,10 +1,9 @@
+import logging
 import os
 import subprocess
-import logging
-from pathlib import Path
-import boto3
 
 logger = logging.getLogger(__name__)
+
 
 class MediaRecorderReceiver:
     def __init__(self, file_location):
@@ -15,7 +14,7 @@ class MediaRecorderReceiver:
 
     def on_encoded_mp4_chunk(self, chunk):
         # Check if file exists and open in appropriate mode
-        mode = 'ab' if os.path.exists(self.file_location) else 'wb'
+        mode = "ab" if os.path.exists(self.file_location) else "wb"
 
         # Write or append data to the file
         with open(self.file_location, mode) as f:
@@ -37,23 +36,22 @@ class MediaRecorderReceiver:
         # log how many bytes are in the file
         logger.info(f"File size: {os.path.getsize(input_path)} bytes")
         command = [
-            'ffmpeg',
-            '-i', str(input_path),
-            '-c', 'copy',  # Copy without re-encoding
-            '-movflags', '+faststart',
-            '-y',  # Overwrite output file without asking
-            str(output_path)
+            "ffmpeg",
+            "-i",
+            str(input_path),
+            "-c",
+            "copy",  # Copy without re-encoding
+            "-movflags",
+            "+faststart",
+            "-y",  # Overwrite output file without asking
+            str(output_path),
         ]
 
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            text=True
-        )
+        result = subprocess.run(command, capture_output=True, text=True)
 
         if result.returncode != 0:
             raise RuntimeError(f"FFmpeg failed: {result.stderr}")
-        
+
         # Replace the original file with the seekable version
         try:
             os.replace(str(output_path), str(input_path))

--- a/bots/bot_controller/media_recorder_receiver.py
+++ b/bots/bot_controller/media_recorder_receiver.py
@@ -1,0 +1,55 @@
+import os
+import subprocess
+import logging
+from pathlib import Path
+import boto3
+
+logger = logging.getLogger(__name__)
+
+class MediaRecorderReceiver:
+    def __init__(self, file_location):
+        self.file_location = file_location
+
+    def cleanup(self):
+        self.make_file_seekable()
+
+    def on_encoded_mp4_chunk(self, chunk):
+        # Check if file exists and open in appropriate mode
+        mode = 'ab' if os.path.exists(self.file_location) else 'wb'
+
+        # Write or append data to the file
+        with open(self.file_location, mode) as f:
+            f.write(chunk)
+
+    def make_file_seekable(self):
+        input_path = self.file_location
+        output_path = self.file_location.with_suffix(".seekable.mp4")
+        """Use ffmpeg to move the moov atom to the beginning of the file."""
+        logger.info(f"Making file seekable: {input_path} -> {output_path}")
+        # log how many bytes are in the file
+        logger.info(f"File size: {os.path.getsize(input_path)} bytes")
+        command = [
+            'ffmpeg',
+            '-i', str(input_path),
+            '-c', 'copy',  # Copy without re-encoding
+            '-movflags', '+faststart',
+            '-y',  # Overwrite output file without asking
+            str(output_path)
+        ]
+
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(f"FFmpeg failed: {result.stderr}")
+        
+        # Replace the original file with the seekable version
+        try:
+            os.replace(str(output_path), str(input_path))
+            logger.info(f"Replaced original file with seekable version: {input_path}")
+        except Exception as e:
+            logger.error(f"Failed to replace original file with seekable version: {e}")
+            raise RuntimeError(f"Failed to replace original file: {e}")

--- a/bots/bot_pod_creator/bot_pod_creator.py
+++ b/bots/bot_pod_creator/bot_pod_creator.py
@@ -70,7 +70,7 @@ class BotPodCreator:
                         command=command,
                         resources=client.V1ResourceRequirements(
                             requests={
-                                "cpu": "2",
+                                "cpu": "4",
                                 "memory": "4Gi",
                                 "ephemeral-storage": "10Gi"
                             },

--- a/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
+++ b/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
@@ -10,3 +10,6 @@ class GoogleMeetBotAdapter(WebBotAdapter, GoogleMeetUIMethods):
 
     def get_websocket_port(self):
         return 8765
+
+    def get_first_buffer_timestamp_ms(self):
+        return self.media_sending_enable_timestamp_ms

--- a/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
+++ b/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
@@ -1,3 +1,239 @@
+class FullCaptureManager {
+    constructor() {
+        this.videoTrack = null;
+        this.audioSources = [];
+        this.mixedAudioTrack = null;
+        this.canvasStream = null;
+        this.finalStream = null;
+        this.mediaRecorder = null;
+        this.recordedChunks = [];
+        this.audioContext = null;
+        this.observer = null;
+        this.audioTracks = [];
+    }
+
+    addAudioTrack(audioTrack) {
+        this.audioTracks.push(audioTrack);
+    }
+
+    async start() {
+        // Find the main element
+        const mainElement = document.querySelector('main');
+        if (!mainElement) {
+            console.error('No <main> element found in the DOM');
+            return;
+        }
+
+        //flush the video bytes
+        //make canvas dixed 1920x1080. scale video elements to fit
+        //make captions line up
+
+        //document.querySelectorAll('body *').forEach(el => el.tagName !== 'VIDEO' && !el.querySelector('video') ? el.style.display = 'none' : '');
+
+        // Create a canvas element with initial dimensions (will be updated later)
+        const canvas = document.createElement('canvas');
+        canvas.width = 1920;  // Default width, will be updated
+        canvas.height = 1080;  // Default height, will be updated
+        document.body.appendChild(canvas);
+
+        // Find all video elements within the main element
+        let videoElements = mainElement.querySelectorAll('video');
+        console.log(`Found ${videoElements.length} video elements in main`);
+
+        // Set up the canvas context for drawing
+        const ctx = canvas.getContext('2d');
+
+        // Create a MutationObserver to watch for changes to the DOM
+        this.observer = new MutationObserver((mutations) => {
+            // Update the list of video elements when DOM changes
+            videoElements = mainElement.querySelectorAll('video');
+            console.log(`Updated: ${videoElements.length} video elements in main`);
+        });
+
+        // Start observing the main element for changes
+        this.observer.observe(mainElement, { 
+            childList: true,      // Watch for added/removed nodes
+            subtree: true,        // Watch all descendants
+            attributes: false,    // Don't need to watch attributes
+            characterData: false  // Don't need to watch text content
+        });
+
+        // Create a drawing function that runs at 30fps
+        const drawVideosToCanvas = () => {            
+            // Clear the canvas with black background
+            ctx.fillStyle = 'black';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+            // Calculate the bounding box that encompasses all videos
+            let minX = Infinity;
+            let minY = Infinity;
+            let maxX = 0;
+            let maxY = 0;
+            let activeVideos = [];
+
+            // Find active videos and determine the bounding box
+            videoElements.forEach(video => {
+                if (!video.paused && video.videoWidth > 0 && video.videoHeight > 0) {
+                    const videoRect = video.getBoundingClientRect();
+                    minX = Math.min(minX, videoRect.left);
+                    minY = Math.min(minY, videoRect.top);
+                    maxX = Math.max(maxX, videoRect.right);
+                    maxY = Math.max(maxY, videoRect.bottom);
+                    activeVideos.push({ video, rect: videoRect });
+                }
+            });
+
+            // If we have active videos, draw them maintaining aspect ratio
+            if (activeVideos.length > 0) {
+                const boundingWidth = maxX - minX;
+                const boundingHeight = maxY - minY;
+
+                // Calculate aspect ratios
+                const inputAspect = boundingWidth / boundingHeight;
+                const outputAspect = canvas.width / canvas.height; // 16:9 for 1920x1080
+
+                let scaledWidth, scaledHeight, offsetX, offsetY;
+
+                if (Math.abs(inputAspect - outputAspect) < 1e-2) {
+                    // Same aspect ratio, use full canvas
+                    scaledWidth = canvas.width;
+                    scaledHeight = canvas.height;
+                    offsetX = 0;
+                    offsetY = 0;
+                } else if (inputAspect > outputAspect) {
+                    // Input is wider, fit to width with letterboxing
+                    scaledWidth = canvas.width;
+                    scaledHeight = canvas.width / inputAspect;
+                    offsetX = 0;
+                    offsetY = (canvas.height - scaledHeight) / 2;
+                } else {
+                    // Input is taller, fit to height with pillarboxing
+                    scaledHeight = canvas.height;
+                    scaledWidth = canvas.height * inputAspect;
+                    offsetX = (canvas.width - scaledWidth) / 2;
+                    offsetY = 0;
+                }
+
+                // Draw each video at its position relative to our bounding box, scaled to fit
+                activeVideos.forEach(({ video, rect }) => {
+                    // Calculate relative position within the bounding box
+                    const relativeX = (rect.left - minX) / boundingWidth;
+                    const relativeY = (rect.top - minY) / boundingHeight;
+                    const relativeWidth = rect.width / boundingWidth;
+                    const relativeHeight = rect.height / boundingHeight;
+
+                    // Apply scaling and position on canvas
+                    ctx.drawImage(
+                        video,
+                        offsetX + relativeX * scaledWidth,
+                        offsetY + relativeY * scaledHeight,
+                        relativeWidth * scaledWidth,
+                        relativeHeight * scaledHeight
+                    );
+                });
+            }
+
+            // Schedule the next frame
+            this.animationFrameId = requestAnimationFrame(drawVideosToCanvas);
+        };
+
+        // Start the drawing loop
+        drawVideosToCanvas();
+
+        // Capture the canvas stream (30fps is typical for video conferencing)
+        const canvasStream = canvas.captureStream(30);
+        const [videoTrack] = canvasStream.getVideoTracks();
+        this.videoTrack = videoTrack;
+        this.canvas = canvas; // Store canvas reference for cleanup
+
+        // Set up audio context and processing as before
+        this.audioContext = new AudioContext();
+
+        this.audioSources = this.audioTracks.map(track => {
+            const mediaStream = new MediaStream([track]);
+            return this.audioContext.createMediaStreamSource(mediaStream);
+        });
+
+        // Create a destination node
+        const destination = this.audioContext.createMediaStreamDestination();
+
+        // Connect all sources to the destination
+        this.audioSources.forEach(source => source.connect(destination));
+
+        this.mixedAudioTrack = destination.stream.getAudioTracks()[0];
+
+        this.finalStream = new MediaStream([
+            this.videoTrack,
+            this.mixedAudioTrack
+        ]);
+
+        // Initialize MediaRecorder with the final stream
+        this.startRecording();
+    }
+
+    startRecording() {
+        // Options for better quality
+        const options = { mimeType: 'video/mp4' };
+        this.mediaRecorder = new MediaRecorder(this.finalStream, options);
+
+        this.recordedChunks = [];
+
+        this.mediaRecorder.ondataavailable = (event) => {
+            if (event.data.size > 0) {
+                console.log('ondataavailable', event.data.size);
+                window.ws.sendEncodedMP4Chunk(event.data);
+            }
+        };
+
+        this.mediaRecorder.onstop = () => {
+            this.saveRecording();
+        };
+
+        // Start recording, collect data in chunks every 1 second
+        this.mediaRecorder.start(1000);
+        console.log("Recording started");
+    }
+
+    stopRecording() {
+        if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
+            this.mediaRecorder.stop();
+            console.log("Recording stopped");
+        }
+    }
+
+    stop() {
+        this.stopRecording();
+
+        // Cancel animation frame if it exists
+        if (this.animationFrameId) {
+            cancelAnimationFrame(this.animationFrameId);
+            this.animationFrameId = null;
+        }
+
+        // Disconnect the MutationObserver
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
+        }
+
+        // Remove canvas element if it exists
+        if (this.canvas) {
+            document.body.removeChild(this.canvas);
+            this.canvas = null;
+        }
+
+        // Stop all tracks
+        if (this.videoTrack) this.videoTrack.stop();
+        if (this.mixedAudioTrack) this.mixedAudioTrack.stop();
+
+        // Clean up
+        this.videoTrack = null;
+        this.mixedAudioTrack = null;
+        this.finalStream = null;
+        this.mediaRecorder = null;
+    }
+}
+
 // Video track manager
 class VideoTrackManager {
     constructor(ws) {
@@ -229,8 +465,9 @@ class WebSocketClient {
   // Message types
   static MESSAGE_TYPES = {
       JSON: 1,
-      VIDEO: 2,  // Reserved for future use
-      AUDIO: 3   // Reserved for future use
+      VIDEO: 2,
+      AUDIO: 3,
+      ENCODED_MP4_CHUNK: 4
   };
 
   constructor() {
@@ -256,13 +493,19 @@ class WebSocketClient {
       };
 
       this.mediaSendingEnabled = false;
+      
+      /*
+      We no longer need this because we're not using MediaStreamTrackProcessor's
       this.lastVideoFrameTime = performance.now();
       this.fillerFrameInterval = null;
 
       this.lastVideoFrame = this.getBlackFrame();
       this.blackVideoFrame = this.getBlackFrame();
+      */
   }
 
+  /*
+  We no longer need this because we're not using MediaStreamTrackProcessor's
   getBlackFrame() {
     // Create black frame data (I420 format)
     const width = 1920, height = 1080;
@@ -307,21 +550,28 @@ class WebSocketClient {
     }, 250);
   }
 
-    stopFillerFrameTimer() {
-        if (this.fillerFrameInterval) {
-            clearInterval(this.fillerFrameInterval);
-            this.fillerFrameInterval = null;
-        }
+  stopFillerFrameTimer() {
+    if (this.fillerFrameInterval) {
+        clearInterval(this.fillerFrameInterval);
+        this.fillerFrameInterval = null;
     }
+  }
+  */
 
   enableMediaSending() {
     this.mediaSendingEnabled = true;
-    this.startFillerFrameTimer();
+    window.fullCaptureManager.start();
+
+    // No longer need this because we're not using MediaStreamTrackProcessor's
+    //this.startFillerFrameTimer();
   }
 
   disableMediaSending() {
+    window.fullCaptureManager.stop();
     this.mediaSendingEnabled = false;
-    this.stopFillerFrameTimer();
+
+    // No longer need this because we're not using MediaStreamTrackProcessor's
+    //this.stopFillerFrameTimer();
   }
 
   handleMessage(data) {
@@ -376,6 +626,32 @@ class WebSocketClient {
         type: 'CaptionUpdate',
         caption: item
     });
+  }
+
+  sendEncodedMP4Chunk(encodedMP4Data) {
+    if (this.ws.readyState !== WebSocket.OPEN) {
+      console.error('WebSocket is not connected for video chunk send', this.ws.readyState);
+      return;
+    }
+
+    if (!this.mediaSendingEnabled) {
+      return;
+    }
+
+    try {
+      // Create a header with just the message type (4 bytes)
+      const headerBuffer = new ArrayBuffer(4);
+      const headerView = new DataView(headerBuffer);
+      headerView.setInt32(0, WebSocketClient.MESSAGE_TYPES.ENCODED_MP4_CHUNK, true);
+
+      // Create a Blob that combines the header and the MP4 data
+      const message = new Blob([headerBuffer, encodedMP4Data]);
+
+      // Send the combined Blob directly
+      this.ws.send(message);
+    } catch (error) {
+      console.error('Error sending WebSocket video chunk:', error);
+    }
   }
 
   sendAudio(timestamp, streamId, audioData) {
@@ -711,9 +987,11 @@ window.ws = ws;
 const userManager = new UserManager(ws);
 const captionManager = new CaptionManager(ws);
 const videoTrackManager = new VideoTrackManager(ws);
+const fullCaptureManager = new FullCaptureManager();
+
 window.videoTrackManager = videoTrackManager;
 window.userManager = userManager;
-
+window.fullCaptureManager = fullCaptureManager;
 // Create decoders for all message types
 const messageDecoders = {};
 messageTypes.forEach(type => {
@@ -1053,6 +1331,23 @@ new RTCInterceptor({
         });
 
         peerConnection.addEventListener('track', (event) => {
+            console.log('New track:', {
+                trackId: event.track.id,
+                trackKind: event.track.kind,
+                streams: event.streams,
+            });
+            // We need to capture every audio track in the meeting,
+            // but we don't need to do anything with the video tracks
+            if (event.track.kind === 'audio') {
+                window.fullCaptureManager.addAudioTrack(event.track);
+            }
+        });
+
+        /*
+        We are no longer setting up per-frame MediaStreamTrackProcessor's because it taxes the CPU too much
+        For now, we are just using the MediaRecorderReceiver to record the video stream
+        but we're keeping this code around for reference
+        peerConnection.addEventListener('track', (event) => {
             // Log the track and its associated streams
             console.log('New track:', {
                 trackId: event.track.id,
@@ -1070,6 +1365,7 @@ new RTCInterceptor({
                 handleVideoTrack(event);
             }
         });
+        */
 
         // Log the signaling state changes
         peerConnection.addEventListener('signalingstatechange', () => {

--- a/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
+++ b/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
@@ -6,7 +6,6 @@ class FullCaptureManager {
         this.canvasStream = null;
         this.finalStream = null;
         this.mediaRecorder = null;
-        this.recordedChunks = [];
         this.audioContext = null;
         this.observer = null;
         this.audioTracks = [];
@@ -226,8 +225,6 @@ class FullCaptureManager {
         // Options for better quality
         const options = { mimeType: 'video/mp4' };
         this.mediaRecorder = new MediaRecorder(this.finalStream, options);
-
-        this.recordedChunks = [];
 
         this.mediaRecorder.ondataavailable = (event) => {
             if (event.data.size > 0) {

--- a/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
+++ b/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
@@ -566,8 +566,10 @@ class WebSocketClient {
     //this.startFillerFrameTimer();
   }
 
-  disableMediaSending() {
+  async disableMediaSending() {
     window.fullCaptureManager.stop();
+    // Give the media recorder a bit of time to send the final data
+    await new Promise(resolve => setTimeout(resolve, 2000));
     this.mediaSendingEnabled = false;
 
     // No longer need this because we're not using MediaStreamTrackProcessor's

--- a/bots/tests/test_can_open_chrome.py
+++ b/bots/tests/test_can_open_chrome.py
@@ -23,7 +23,7 @@ class TestChromeDriver(TransactionTestCase):
             options.add_argument("--disable-dev-shm-usage")
 
             # Initialize Chrome driver
-            driver = uc.Chrome(use_subprocess=True, options=options, version_main=133)
+            driver = uc.Chrome(use_subprocess=True, options=options, version_main=134)
 
             try:
                 # Load Google

--- a/bots/tests/test_google_meet_bot.py
+++ b/bots/tests/test_google_meet_bot.py
@@ -2,6 +2,7 @@ import os
 import threading
 import time
 from unittest.mock import MagicMock, call, patch
+import base64
 
 import kubernetes
 import numpy as np
@@ -124,24 +125,17 @@ class TestGoogleMeetBot(TransactionTestCase):
             # Add participants - simulate websocket message processing
             controller.adapter.participants_info["user1"] = {"deviceId": "user1", "fullName": "Test User", "active": True}
 
-            # Simulate audio data arrival - fake a float32 array of 1000 samples
-            # Create a mock audio message in the format expected by process_audio_frame
-            mock_audio_message = bytearray()
-            # Add message type (3 for AUDIO) as first 4 bytes
-            mock_audio_message.extend((3).to_bytes(4, byteorder="little"))
-            # Add timestamp (12345) as next 8 bytes
-            mock_audio_message.extend((12345).to_bytes(8, byteorder="little"))
-            # Add stream ID (0) as next 4 bytes
-            mock_audio_message.extend((0).to_bytes(4, byteorder="little"))
-            # Add mock audio data (1000 float32 samples)
-            mock_audio_message.extend(MockF32AudioFrame().GetBuffer())
+            # Simulate encoded MP4 chunk arrival
+            # Create a mock MP4 message in the format expected by process_encoded_mp4_chunk
+            mock_mp4_message = bytearray()
+            # Add message type (4 for ENCODED_MP4_CHUNK) as first 4 bytes
+            mock_mp4_message.extend((4).to_bytes(4, byteorder="little"))
+            # Add sample MP4 data (just a small dummy chunk for testing)
+            tiny_mp4_base64 = "GkXfo0AgQoaBAUL3gQFC8oEEQvOBCEKCQAR3ZWJtQoeBAkKFgQIYU4BnQI0VSalmQCgq17FAAw9CQE2AQAZ3aGFtbXlXQUAGd2hhbW15RIlACECPQAAAAAAAFlSua0AxrkAu14EBY8WBAZyBACK1nEADdW5khkAFVl9WUDglhohAA1ZQOIOBAeBABrCBCLqBCB9DtnVAIueBAKNAHIEAAIAwAQCdASoIAAgAAUAmJaQAA3AA/vz0AAA="
+            mock_mp4_data = base64.b64decode(tiny_mp4_base64)
+            mock_mp4_message.extend(mock_mp4_data)
 
-            controller.adapter.process_audio_frame(mock_audio_message)
-
-            # Simulate video data arrival
-            # Create a mock video message in the format expected by process_video_frame
-            mock_video_frame = create_mock_video_frame()
-            controller.adapter.process_video_frame(mock_video_frame)
+            controller.adapter.process_encoded_mp4_chunk(mock_mp4_message)
 
             # Simulate caption data arrival
             caption_data = {"captionId": "caption1", "deviceId": "user1", "text": "This is a test caption"}

--- a/bots/tests/test_google_meet_bot.py
+++ b/bots/tests/test_google_meet_bot.py
@@ -1,8 +1,8 @@
+import base64
 import os
 import threading
 import time
 from unittest.mock import MagicMock, call, patch
-import base64
 
 import kubernetes
 import numpy as np
@@ -27,8 +27,6 @@ from bots.models import (
     TranscriptionTypes,
     Utterance,
 )
-
-from .mock_data import MockF32AudioFrame
 
 
 def create_mock_file_uploader():

--- a/bots/tests/test_google_meet_bot.py
+++ b/bots/tests/test_google_meet_bot.py
@@ -225,9 +225,6 @@ class TestGoogleMeetBot(TransactionTestCase):
         self.assertIsNotNone(caption_utterance)
         self.assertEqual(caption_utterance.transcription.get("transcript"), "This is a test caption")
 
-        # Verify driver was set up with the correct window size
-        mock_driver.set_window_size.assert_called_with(1920 / 2, 1080 / 2)
-
         # Verify WebSocket media sending was enabled and performance.timeOrigin was queried
         mock_driver.execute_script.assert_has_calls([call("window.ws?.enableMediaSending();"), call("return performance.timeOrigin;")])
 

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -465,9 +465,6 @@ class WebBotAdapter(BotAdapter):
             num_retries += 1
             sleep(1)
 
-        # Trying making it smaller so GMeet sends smaller video frames
-        self.driver.set_window_size(1920 / 2, 1080 / 2)
-
         self.send_message_callback({"message": self.Messages.BOT_JOINED_MEETING})
         self.send_message_callback({"message": self.Messages.BOT_RECORDING_PERMISSION_GRANTED})
 

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -173,7 +173,7 @@ class WebBotAdapter(BotAdapter):
         self.last_audio_message_processed_time = None
         self.first_buffer_timestamp_ms_offset = time.time() * 1000
         self.media_sending_enable_timestamp_ms = None
-        
+
         self.participants_info = {}
         self.only_one_participant_in_meeting_at = None
         self.video_frame_ticker = 0

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -172,7 +172,8 @@ class WebBotAdapter(BotAdapter):
         self.last_media_message_processed_time = None
         self.last_audio_message_processed_time = None
         self.first_buffer_timestamp_ms_offset = time.time() * 1000
-
+        self.media_sending_enable_timestamp_ms = None
+        
         self.participants_info = {}
         self.only_one_participant_in_meeting_at = None
         self.video_frame_ticker = 0
@@ -482,6 +483,7 @@ class WebBotAdapter(BotAdapter):
         self.send_frames = True
         self.driver.execute_script("window.ws?.enableMediaSending();")
         self.first_buffer_timestamp_ms_offset = self.driver.execute_script("return performance.timeOrigin;")
+        self.media_sending_enable_timestamp_ms = time.time() * 1000
 
     def leave(self):
         if self.left_meeting:

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -299,7 +299,6 @@ class WebBotAdapter(BotAdapter):
                                 self.only_one_participant_in_meeting_at = None
 
                         elif json_data.get("type") == "SilenceStatus":
-                            logger.info(f"silence status {json_data.get('isSilent')}")
                             if json_data.get("isSilent") == False:
                                 self.last_audio_message_processed_time = time.time()
 

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -299,7 +299,7 @@ class WebBotAdapter(BotAdapter):
                                 self.only_one_participant_in_meeting_at = None
 
                         elif json_data.get("type") == "SilenceStatus":
-                            if json_data.get("isSilent") == False:
+                            if not json_data.get("isSilent"):
                                 self.last_audio_message_processed_time = time.time()
 
                 elif message_type == 2:  # VIDEO

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -298,6 +298,11 @@ class WebBotAdapter(BotAdapter):
                             else:
                                 self.only_one_participant_in_meeting_at = None
 
+                        elif json_data.get("type") == "SilenceStatus":
+                            logger.info(f"silence status {json_data.get('isSilent')}")
+                            if json_data.get("isSilent") == False:
+                                self.last_audio_message_processed_time = time.time()
+
                 elif message_type == 2:  # VIDEO
                     self.process_video_frame(message)
                 elif message_type == 3:  # AUDIO
@@ -558,7 +563,7 @@ class WebBotAdapter(BotAdapter):
 
         if self.last_audio_message_processed_time is not None:
             if time.time() - self.last_audio_message_processed_time > self.automatic_leave_configuration.silence_threshold_seconds:
-                logger.info(f"Auto-leaving meeting because there was no media message for {self.automatic_leave_configuration.silence_threshold_seconds} seconds")
+                logger.info(f"Auto-leaving meeting because there was no audio for {self.automatic_leave_configuration.silence_threshold_seconds} seconds")
                 self.send_message_callback({"message": self.Messages.ADAPTER_REQUESTED_BOT_LEAVE_MEETING, "leave_reason": BotAdapter.LEAVE_REASON.AUTO_LEAVE_SILENCE})
                 return
 

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -369,8 +369,6 @@ class WebBotAdapter(BotAdapter):
         )
 
     def init_driver(self):
-        log_path = "chromedriver.log"
-
         options = uc.ChromeOptions()
 
         options.add_argument("--use-fake-ui-for-media-stream")
@@ -397,11 +395,11 @@ class WebBotAdapter(BotAdapter):
             self.driver = None
 
         self.driver = uc.Chrome(
-            service_log_path=log_path,
             use_subprocess=True,
             options=options,
             version_main=133,
         )
+        logger.info(f"web driver server initialized at port {self.driver.service.port}")
 
         initial_data_code = f"window.initialData = {{websocketPort: {self.websocket_port}}}"
 

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -397,7 +397,7 @@ class WebBotAdapter(BotAdapter):
         self.driver = uc.Chrome(
             use_subprocess=True,
             options=options,
-            version_main=133,
+            version_main=134,
         )
         logger.info(f"web driver server initialized at port {self.driver.service.port}")
 


### PR DESCRIPTION
This PR introduces a different strategy for recording Google Meets. We basically track the `<video>` elements on the page and composit them onto a canvas. The canvas is then captured using MediaRecorder. So essentially what gstreamer used to do, we are doing in the browser. This is less taxing on the CPU. The previous strategy of capturing every raw frame and sending it over websockets to be composited was causing the video and audio to go out of sink.

The downside of this strategy is that it introduces duplication between gstreamer (used for zoom meetings) and the frontend code.