### PR TITLE
Fixed path to references

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -13,7 +13,7 @@
   "references": [
     {
       "name": "API Reference",
-      "path": "docs/openapi.yaml"
+      "path": "docs/openapi.yml"
     }
   ],
   "publishOnMerge": true


### PR DESCRIPTION
Corrected path to api docs for scalar.

Fixes this issue: 

<img width="688" alt="image" src="https://github.com/user-attachments/assets/125c7b00-7908-4cc7-ade3-5482a8f7ec09" />
