### PR TITLE
Makefile for convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+.PHONY: build
+build:  ## Build the application
+	docker compose -f dev.docker-compose.yaml build
+
+.PHONY: up
+up: ## Start the application
+	docker compose -f dev.docker-compose.yaml up
+
+.PHONY: down
+down: ## Stop the application
+	docker compose -f dev.docker-compose.yaml down
+
+.PHONY: migrate
+migrate: ## Run migrations
+	docker compose -f dev.docker-compose.yaml exec attendee-app-local python manage.py migrate
+

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,16 @@ build:  ## Build the application
 	docker compose -f dev.docker-compose.yaml build
 
 .PHONY: up
-up: ## Start the application
-	docker compose -f dev.docker-compose.yaml up
+up: ## Start the application as a background process
+	docker compose -f dev.docker-compose.yaml up -d
 
 .PHONY: down
 down: ## Stop the application
 	docker compose -f dev.docker-compose.yaml down
+
+.PHONY: logs
+logs: ## View the logs
+	docker compose -f dev.docker-compose.yaml logs -f
 
 .PHONY: migrate
 migrate: ## Run migrations

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,7 @@ logs: ## View the logs
 migrate: ## Run migrations
 	docker compose -f dev.docker-compose.yaml exec attendee-app-local python manage.py migrate
 
+.PHONY: lint
+lint: ## Run the ruff linter.
+	ruff check --fix
+	ruff format


### PR DESCRIPTION
@noah-duncan  You are free to reject this PR if not needed/useful. 

Situation: I often find myself restarting containers during development. It’s easier for me to remember make commands rather than docker commands. For example, I prefer `make up` over `docker compose -f dev.docker-compose.yaml up`.

If I’m in a different terminal, I can run `make logs` to view the running logs in the app container.

Keeping the migrations up-to-date is also simple with `make migrations`.

`make lint` to manually run the linter.

This comes with a useful menu: 





```bash
$ make

Usage:
  make <target>
  help             Display this help.
  build            Build the application
  up               Start the application as a background process
  down             Stop the application
  logs             View the logs
  migrate          Run migrations
  lint             Run the ruff linter.
```