### PR TITLE
Add parameter for customizing google meet closed caption language

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -63,6 +63,7 @@ class BotController:
             automatic_leave_configuration=self.automatic_leave_configuration,
             add_encoded_mp4_chunk_callback=self.media_recorder_receiver.on_encoded_mp4_chunk,
             recording_view=self.bot_in_db.recording_view(),
+            google_meet_closed_captions_language=self.bot_in_db.google_meet_closed_captions_language(),
         )
 
     def get_teams_bot_adapter(self):

--- a/bots/bot_controller/media_recorder_receiver.py
+++ b/bots/bot_controller/media_recorder_receiver.py
@@ -35,7 +35,7 @@ class MediaRecorderReceiver:
         # Check if input file exists
         if not os.path.exists(input_path):
             logger.info(f"Input file does not exist at {input_path}, creating empty file")
-            with open(input_path, "wb") as f:
+            with open(input_path, "wb"):
                 pass  # Create empty file
             return
 

--- a/bots/bot_controller/media_recorder_receiver.py
+++ b/bots/bot_controller/media_recorder_receiver.py
@@ -31,14 +31,14 @@ class MediaRecorderReceiver:
     def make_file_seekable(self):
         input_path = self.file_location
         output_path = self.get_seekable_path(self.file_location)
-        
+
         # Check if input file exists
         if not os.path.exists(input_path):
             logger.info(f"Input file does not exist at {input_path}, creating empty file")
-            with open(input_path, 'wb') as f:
+            with open(input_path, "wb") as f:
                 pass  # Create empty file
             return
-            
+
         """Use ffmpeg to move the moov atom to the beginning of the file."""
         logger.info(f"Making file seekable: {input_path} -> {output_path}")
         # log how many bytes are in the file

--- a/bots/bot_controller/media_recorder_receiver.py
+++ b/bots/bot_controller/media_recorder_receiver.py
@@ -31,6 +31,14 @@ class MediaRecorderReceiver:
     def make_file_seekable(self):
         input_path = self.file_location
         output_path = self.get_seekable_path(self.file_location)
+        
+        # Check if input file exists
+        if not os.path.exists(input_path):
+            logger.info(f"Input file does not exist at {input_path}, creating empty file")
+            with open(input_path, 'wb') as f:
+                pass  # Create empty file
+            return
+            
         """Use ffmpeg to move the moov atom to the beginning of the file."""
         logger.info(f"Making file seekable: {input_path} -> {output_path}")
         # log how many bytes are in the file

--- a/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
+++ b/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
@@ -5,6 +5,15 @@ from bots.web_bot_adapter import WebBotAdapter
 
 
 class GoogleMeetBotAdapter(WebBotAdapter, GoogleMeetUIMethods):
+    def __init__(
+        self,
+        *args,
+        google_meet_closed_captions_language: str | None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.google_meet_closed_captions_language = google_meet_closed_captions_language
+
     def get_chromedriver_payload_file_name(self):
         return "google_meet_bot_adapter/google_meet_chromedriver_payload.js"
 

--- a/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
+++ b/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
@@ -9,7 +9,7 @@ class GoogleMeetBotAdapter(WebBotAdapter, GoogleMeetUIMethods):
         self,
         *args,
         google_meet_closed_captions_language: str | None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.google_meet_closed_captions_language = google_meet_closed_captions_language

--- a/bots/google_meet_bot_adapter/google_meet_ui_methods.py
+++ b/bots/google_meet_bot_adapter/google_meet_ui_methods.py
@@ -4,6 +4,7 @@ from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.action_chains import ActionChains
 
 from bots.models import RecordingViews
 from bots.web_bot_adapter.ui_methods import UiCouldNotClickElementException, UiCouldNotLocateElementException, UiRequestToJoinDeniedException, UiRetryableException
@@ -239,6 +240,80 @@ class GoogleMeetUIMethods:
         close_button = self.locate_element(
             step="close_button",
             condition=EC.presence_of_element_located((By.CSS_SELECTOR, 'button[aria-label="Close"]')),
+            wait_time_seconds=6,
+        )
+        logger.info("Clicking the close button")
+        self.click_element(close_button, "close_button")
+
+        if self.google_meet_closed_captions_language:
+            self.select_language(self.google_meet_closed_captions_language)
+
+    def scroll_element_into_view(self, element, step):
+        try:
+            actions = ActionChains(self.driver)
+            actions.move_to_element(element).perform()
+            logger.info(f"Scrolled element into view for {step}")
+        except Exception as e:
+            logger.info(f"Error scrolling element into view for {step}")
+            raise UiCouldNotLocateElementException(f"Error scrolling element into view", step, e)
+
+    def select_language(self, language):
+        logger.info(f"Selecting language: {language}")
+        logger.info("Waiting for the more options button...")
+        MORE_OPTIONS_BUTTON_SELECTOR = 'button[jsname="NakZHc"][aria-label="More options"]'
+        more_options_button = self.locate_element(
+            step="more_options_button_for_language_selection",
+            condition=EC.presence_of_element_located((By.CSS_SELECTOR, MORE_OPTIONS_BUTTON_SELECTOR)),
+            wait_time_seconds=6,
+        )
+        logger.info("Clicking the more options button...")
+        self.click_element(more_options_button, "more_options_button")
+
+        logger.info("Waiting for the settings list item...")
+        settings_list_item = self.locate_element(
+            step="settings_list_item",
+            condition=EC.presence_of_element_located((By.XPATH, '//li[.//span[text()="Settings"]]')),
+            wait_time_seconds=6,
+        )
+        logger.info("Clicking the settings list item...")
+        self.click_element(settings_list_item, "settings_list_item")
+
+        logger.info("Waiting for the captions button")
+        captions_button = self.locate_element(
+            step="captions_button",
+            condition=EC.presence_of_element_located((By.CSS_SELECTOR, 'button[jsname="z4Tpl"][aria-label="Captions"]')),
+            wait_time_seconds=6,
+        )
+        logger.info("Clicking the captions button...")
+        self.click_element(captions_button, "captions_button")
+
+        logger.info("Waiting for the language dropdown")
+        language_dropdown = self.locate_element(
+            step="language_dropdown",
+            condition=EC.presence_of_element_located((By.XPATH, '//div[@jsname="oYxtQd"][.//span[contains(text(), "Language of the meeting")]]')),
+            wait_time_seconds=6,
+        )
+        logger.info("Clicking the language dropdown...")
+        self.click_element(language_dropdown, "language_dropdown")
+
+        logger.info(f"Waiting for the language option: {language}...")
+        language_option = self.locate_element(
+            step="language_option",
+            condition=EC.presence_of_element_located((By.CSS_SELECTOR, f'li[data-value="{language}"]')),
+            wait_time_seconds=6,
+        )
+        
+        # Scroll the language option into view before clicking
+        logger.info(f"Scrolling language option into view: {language}...")
+        self.scroll_element_into_view(language_option, "language_option")
+        
+        logger.info(f"Clicking the language option: {language}...")
+        self.click_element(language_option, "language_option")
+
+        logger.info("Waiting for the close button")
+        close_button = self.locate_element(
+            step="close_button_for_language_selection",
+            condition=EC.presence_of_element_located((By.CSS_SELECTOR, 'button[aria-label="Close dialog"]')),
             wait_time_seconds=6,
         )
         logger.info("Clicking the close button")

--- a/bots/google_meet_bot_adapter/google_meet_ui_methods.py
+++ b/bots/google_meet_bot_adapter/google_meet_ui_methods.py
@@ -1,10 +1,10 @@
 import logging
 
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.common.action_chains import ActionChains
 
 from bots.models import RecordingViews
 from bots.web_bot_adapter.ui_methods import UiCouldNotClickElementException, UiCouldNotLocateElementException, UiRequestToJoinDeniedException, UiRetryableException
@@ -255,7 +255,11 @@ class GoogleMeetUIMethods:
             logger.info(f"Scrolled element into view for {step}")
         except Exception as e:
             logger.info(f"Error scrolling element into view for {step}")
-            raise UiCouldNotLocateElementException(f"Error scrolling element into view", step, e)
+            raise UiCouldNotLocateElementException(
+                "Error scrolling element into view",
+                step,
+                e,
+            )
 
     def select_language(self, language):
         logger.info(f"Selecting language: {language}")
@@ -302,11 +306,11 @@ class GoogleMeetUIMethods:
             condition=EC.presence_of_element_located((By.CSS_SELECTOR, f'li[data-value="{language}"]')),
             wait_time_seconds=6,
         )
-        
+
         # Scroll the language option into view before clicking
         logger.info(f"Scrolling language option into view: {language}...")
         self.scroll_element_into_view(language_option, "language_option")
-        
+
         logger.info(f"Clicking the language option: {language}...")
         self.click_element(language_option, "language_option")
 

--- a/bots/models.py
+++ b/bots/models.py
@@ -182,6 +182,9 @@ class Bot(models.Model):
     def deepgram_detect_language(self):
         return self.settings.get("transcription_settings", {}).get("deepgram", {}).get("detect_language", None)
 
+    def google_meet_closed_captions_language(self):
+        return self.settings.get("transcription_settings", {}).get("meeting_closed_captions", {}).get("google_meet_language", None)
+
     def rtmp_destination_url(self):
         rtmp_settings = self.settings.get("rtmp_settings")
         if not rtmp_settings:

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -19,7 +19,6 @@ from .models import (
 )
 from .utils import meeting_type_from_url
 
-
 @extend_schema_field(
     {
         "type": "object",
@@ -36,9 +35,18 @@ from .utils import meeting_type_from_url
                         "description": "Whether to automatically detect the spoken language",
                     },
                 },
-            }
+            },
+            "meeting_closed_captions": {
+                "type": "object",
+                "properties": {
+                    "google_meet_language": {
+                        "type": "string",
+                        "description": "The language code for Google Meet closed captions (e.g. 'en-US'). See here for available languages and codes: https://docs.google.com/spreadsheets/d/1MN44lRrEBaosmVI9rtTzKMii86zGgDwEwg4LSj-SjiE",
+                    },
+                },
+            },            
         },
-        "required": ["deepgram"],
+        "required": [],
     }
 )
 class TranscriptionSettingsJSONField(serializers.JSONField):
@@ -123,9 +131,17 @@ class CreateBotSerializer(serializers.Serializer):
                     {"required": ["detect_language"]},
                 ],
                 "additionalProperties": False,
-            }
+            },
+            "meeting_closed_captions": {
+                "type": "object",
+                "properties": {
+                    "google_meet_language": {"type": "string"},
+                },
+                "required": [],
+                "additionalProperties": False,
+            },
         },
-        "required": ["deepgram"],
+        "required": [],
         "additionalProperties": False,
     }
 

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -19,6 +19,7 @@ from .models import (
 )
 from .utils import meeting_type_from_url
 
+
 @extend_schema_field(
     {
         "type": "object",
@@ -44,7 +45,7 @@ from .utils import meeting_type_from_url
                         "description": "The language code for Google Meet closed captions (e.g. 'en-US'). See here for available languages and codes: https://docs.google.com/spreadsheets/d/1MN44lRrEBaosmVI9rtTzKMii86zGgDwEwg4LSj-SjiE",
                     },
                 },
-            },            
+            },
         },
         "required": [],
     }


### PR DESCRIPTION
Adds the ability to set the language the bot uses for Google Meet's closed captions. The language is specified in the API call like this:

`
curl -X POST https://app.attendee.dev/api/v1/bots -H 'Authorization: Token xxxx' -H 'Content-Type: application/json' -d '{"meeting_url":"https://meet.google.com/xx","bot_name":"MyBot","transcription_settings":{"meeting_closed_captions":{"google_meet_language":<LANGUAGE CODE>}}}'
`

A list of supported languages is here:
https://docs.google.com/spreadsheets/d/1MN44lRrEBaosmVI9rtTzKMii86zGgDwEwg4LSj-SjiE