### PR TITLE
Fix bug with deepgram for other languages

### DIFF
--- a/bots/tasks/process_utterance_task.py
+++ b/bots/tasks/process_utterance_task.py
@@ -64,7 +64,7 @@ def process_utterance(self, utterance_id):
         utterance.transcription = json.loads(response.results.channels[0].alternatives[0].to_json())
         utterance.audio_blob = b""  # set the binary field to empty byte string
         utterance.save()
-        
+
         logger.info(f"Transcription complete for utterance {utterance_id} with model {deepgram_model}")
 
     # If the recording is in a terminal state and there are no more utterances to transcribe, set the recording's transcription state to complete

--- a/bots/tasks/process_utterance_task.py
+++ b/bots/tasks/process_utterance_task.py
@@ -35,8 +35,14 @@ def process_utterance(self, utterance_id):
             "buffer": utterance.audio_blob.tobytes(),
         }
 
+        # nova-3 does not have multilingual support yet, so we need to use nova-2 if we're transcribing with a non-default language
+        if (recording.bot.deepgram_language() != "en" and recording.bot.deepgram_language()) or recording.bot.deepgram_detect_language():
+            deepgram_model = "nova-2"
+        else:
+            deepgram_model = "nova-3"
+
         options = PrerecordedOptions(
-            model="nova-3",
+            model=deepgram_model,
             smart_format=True,
             language=recording.bot.deepgram_language(),
             detect_language=recording.bot.deepgram_detect_language(),
@@ -58,6 +64,8 @@ def process_utterance(self, utterance_id):
         utterance.transcription = json.loads(response.results.channels[0].alternatives[0].to_json())
         utterance.audio_blob = b""  # set the binary field to empty byte string
         utterance.save()
+        
+        logger.info(f"Transcription complete for utterance {utterance_id} with model {deepgram_model}")
 
     # If the recording is in a terminal state and there are no more utterances to transcribe, set the recording's transcription state to complete
     if RecordingManager.is_terminal_state(utterance.recording.state) and Utterance.objects.filter(recording=utterance.recording, transcription__isnull=True).count() == 0:


### PR DESCRIPTION
It turns out deepgram's latest model nova-3 doesn't support non-english transcription currently. This PR adds logic to use nova-3 only when we're doing english transcription. Otherwise use the previous model nova-2