### PR TITLE
Fix a few more gmeet cases

### DIFF
--- a/bots/google_meet_bot_adapter/google_meet_ui_methods.py
+++ b/bots/google_meet_bot_adapter/google_meet_ui_methods.py
@@ -58,10 +58,7 @@ class GoogleMeetUIMethods:
             others_may_see_your_meeting_differently_button.click()
 
     def look_for_blocked_element(self, step):
-        cannot_join_element = self.find_element_by_selector(
-            By.XPATH, 
-            '//*[contains(text(), "You can\'t join this video call") or contains(text(), "There is a problem connecting to this video call")]'
-        )
+        cannot_join_element = self.find_element_by_selector(By.XPATH, '//*[contains(text(), "You can\'t join this video call") or contains(text(), "There is a problem connecting to this video call")]')
         if cannot_join_element:
             # This means google is blocking us for whatever reason, but we can retry
             logger.info("Google is blocking us for whatever reason, but we can retry. Raising UiGoogleBlockingUsException")

--- a/bots/google_meet_bot_adapter/google_meet_ui_methods.py
+++ b/bots/google_meet_bot_adapter/google_meet_ui_methods.py
@@ -58,7 +58,10 @@ class GoogleMeetUIMethods:
             others_may_see_your_meeting_differently_button.click()
 
     def look_for_blocked_element(self, step):
-        cannot_join_element = self.find_element_by_selector(By.XPATH, '//*[contains(text(), "You can\'t join this video call")]')
+        cannot_join_element = self.find_element_by_selector(
+            By.XPATH, 
+            '//*[contains(text(), "You can\'t join this video call") or contains(text(), "There is a problem connecting to this video call")]'
+        )
         if cannot_join_element:
             # This means google is blocking us for whatever reason, but we can retry
             logger.info("Google is blocking us for whatever reason, but we can retry. Raising UiGoogleBlockingUsException")
@@ -120,7 +123,11 @@ class GoogleMeetUIMethods:
                 self.click_element(captions_button, "click_captions_button")
                 return
             except UiCouldNotClickElementException as e:
-                raise e
+                self.click_others_may_see_your_meeting_differently_button("click_captions_button")
+                last_check_could_not_click_element = attempt_to_look_for_captions_button_index == num_attempts_to_look_for_captions_button - 1
+                if last_check_could_not_click_element:
+                    logger.info("Could not click captions button. Raising UiCouldNotClickElementException")
+                    raise e
             except TimeoutException as e:
                 self.look_for_blocked_element("click_captions_button")
                 self.look_for_denied_your_request_element("click_captions_button")
@@ -147,7 +154,7 @@ class GoogleMeetUIMethods:
                 )
 
     def check_if_meeting_is_found(self):
-        meeting_not_found_element = self.find_element_by_selector(By.XPATH, '//*[contains(text(), "Check your meeting code") or contains(text(), "Invalid video call name")]')
+        meeting_not_found_element = self.find_element_by_selector(By.XPATH, '//*[contains(text(), "Check your meeting code") or contains(text(), "Invalid video call name") or contains(text(), "Your meeting code has expired")]')
         if meeting_not_found_element:
             logger.info("Meeting not found. Raising UiMeetingNotFoundException")
             raise UiMeetingNotFoundException("Meeting not found", "check_if_meeting_is_found")

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -376,7 +376,7 @@ class WebBotAdapter(BotAdapter):
         # Expected exceptions are ones that we expect to happen and are not a big deal, so we only increment num_retries once every three expected exceptions
         num_expected_exceptions = 0
         num_retries = 0
-        max_retries = 2
+        max_retries = 3
         while num_retries <= max_retries:
             try:
                 self.init_driver()


### PR DESCRIPTION
Handles the `There is a problem connecting to this video call` case, classifying it as an expected exception so it can be retries more times.

Handle case where the  'Others may see you differently' modal blocks clicking the caption button.

Handles 'Your meeting code has expired' case.