### PR TITLE
Add updated after param to transcript endpoint

### DIFF
--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -614,7 +614,11 @@ class TranscriptView(APIView):
             # Apply updated_after filter if provided
             updated_after = request.query_params.get("updated_after")
             if updated_after:
-                updated_after_datetime = parse_datetime(str(updated_after))
+                try:
+                    updated_after_datetime = parse_datetime(str(updated_after))
+                except Exception:
+                    updated_after_datetime = None
+
                 if not updated_after_datetime:
                     return Response(
                         {"error": "Invalid updated_after format. Use ISO 8601 format (e.g., 2024-01-18T12:34:56Z)"},

--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -6,6 +6,7 @@ import redis
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.urls import reverse
+from django.utils.dateparse import parse_datetime
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
@@ -16,7 +17,6 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from django.utils.dateparse import parse_datetime
 from .authentication import ApiKeyAuthentication
 from .models import (
     Bot,
@@ -609,13 +609,10 @@ class TranscriptView(APIView):
                 )
 
             # Get all utterances with transcriptions, sorted by timeline
-            utterances_query = Utterance.objects.select_related("participant").filter(
-                recording=recording, 
-                transcription__isnull=False
-            )
-            
+            utterances_query = Utterance.objects.select_related("participant").filter(recording=recording, transcription__isnull=False)
+
             # Apply updated_after filter if provided
-            updated_after = request.query_params.get('updated_after')
+            updated_after = request.query_params.get("updated_after")
             if updated_after:
                 updated_after_datetime = parse_datetime(str(updated_after))
                 if not updated_after_datetime:
@@ -624,8 +621,7 @@ class TranscriptView(APIView):
                         status=status.HTTP_400_BAD_REQUEST,
                     )
                 utterances_query = utterances_query.filter(updated_at__gt=updated_after_datetime)
-                
-            
+
             # Apply ordering
             utterances = utterances_query.order_by("timestamp_ms")
 

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -428,6 +428,17 @@ paths:
           BotIDExample:
             value: bot_xxxxxxxxxxx
             summary: Bot ID Example
+      - in: query
+        name: updated_after
+        schema:
+          type: string
+          format: ISO 8601 datetime
+        description: Only return transcript entries updated or created after this
+          time. Useful when polling for updates to the transcript.
+        examples:
+          DateTimeExample:
+            value: '2024-01-18T12:34:56Z'
+            summary: DateTime Example
       tags:
       - Bots
       security:


### PR DESCRIPTION
Adds a query param to the /transcript endpoint that can be used to only return transcript entries created or updated after a given time. This is useful for efficiently polling for changes to the transcript.