### PR TITLE
Bots should attempt to reconnect redis if server closes connection

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -303,6 +303,12 @@ class BotController:
         return not self.should_create_gstreamer_pipeline()
 
     def connect_to_redis(self):
+        # Close both pubsub and client if they exist
+        if self.pubsub:
+            self.pubsub.close()
+        if self.redis_client:
+            self.redis_client.close()
+
         redis_url = os.getenv("REDIS_URL") + ("?ssl_cert_reqs=none" if os.getenv("DISABLE_REDIS_SSL") else "")
         self.redis_client = redis.from_url(redis_url)
         self.pubsub = self.redis_client.pubsub()
@@ -367,8 +373,7 @@ class BotController:
             reconnect_delay_seconds = 1
             num_attempts = 0
             while True:
-                try:
-                    self.pubsub.close()
+                try:                    
                     self.connect_to_redis()
                     break
                 except Exception as e:

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -392,7 +392,7 @@ class BotController:
                         GLib.idle_add(lambda: self.handle_redis_message(message))
                 except Exception as e:
                     # If this is a certain type of exception, we can attempt to reconnect
-                    if type(e) == redis.exceptions.ConnectionError and "Connection closed by server." in str(e):
+                    if isinstance(e, redis.exceptions.ConnectionError) and "Connection closed by server." in str(e):
                         logger.info("Redis connection closed by server. Attempting to reconnect...")
                         repeatedly_try_to_reconnect_to_redis()
 

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -258,7 +258,7 @@ class BotController:
 
         self.redis_client = None
         self.pubsub = None
-        self.channel = f"bot_{self.bot_in_db.id}"
+        self.pubsub_channel = f"bot_{self.bot_in_db.id}"
 
         self.automatic_leave_configuration = AutomaticLeaveConfiguration()
 
@@ -306,7 +306,7 @@ class BotController:
         redis_url = os.getenv("REDIS_URL") + ("?ssl_cert_reqs=none" if os.getenv("DISABLE_REDIS_SSL") else "")
         self.redis_client = redis.from_url(redis_url)
         self.pubsub = self.redis_client.pubsub()
-        self.pubsub.subscribe(self.channel)
+        self.pubsub.subscribe(self.pubsub_channel)
         logger.info(f"Redis connection established for bot {self.bot_in_db.id}")
 
     def run(self):
@@ -415,7 +415,7 @@ class BotController:
             self.cleanup()
         finally:
             # Clean up Redis subscription
-            self.pubsub.unsubscribe(self.channel)
+            self.pubsub.unsubscribe(self.pubsub_channel)
             self.pubsub.close()
 
     def take_action_based_on_bot_in_db(self):

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -373,7 +373,7 @@ class BotController:
             reconnect_delay_seconds = 1
             num_attempts = 0
             while True:
-                try:                    
+                try:
                     self.connect_to_redis()
                     break
                 except Exception as e:

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -30,7 +30,7 @@ from bots.models import (
     Utterance,
 )
 from bots.utils import meeting_type_from_url
-
+import threading
 from .audio_output_manager import AudioOutputManager
 from .automatic_leave_configuration import AutomaticLeaveConfiguration
 from .closed_caption_manager import ClosedCaptionManager
@@ -40,6 +40,7 @@ from .individual_audio_input_manager import IndividualAudioInputManager
 from .pipeline_configuration import PipelineConfiguration
 from .rtmp_client import RTMPClient
 from .screen_and_audio_recorder import ScreenAndAudioRecorder
+import time
 
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib
@@ -254,6 +255,10 @@ class BotController:
         self.cleanup_called = False
         self.run_called = False
 
+        self.redis_client = None
+        self.pubsub = None
+        self.channel = f"bot_{self.bot_in_db.id}"
+
         self.automatic_leave_configuration = AutomaticLeaveConfiguration()
 
         if self.bot_in_db.rtmp_destination_url():
@@ -296,16 +301,19 @@ class BotController:
     def should_create_screen_and_audio_recorder(self):
         return not self.should_create_gstreamer_pipeline()
 
+    def connect_to_redis(self):
+        redis_url = os.getenv("REDIS_URL") + ("?ssl_cert_reqs=none" if os.getenv("DISABLE_REDIS_SSL") else "")
+        self.redis_client = redis.from_url(redis_url)
+        self.pubsub = self.redis_client.pubsub()
+        self.pubsub.subscribe(self.channel)
+        logger.info(f"Redis connection established for bot {self.bot_in_db.id}")
+
     def run(self):
         if self.run_called:
             raise Exception("Run already called, exiting")
         self.run_called = True
 
-        redis_url = os.getenv("REDIS_URL") + ("?ssl_cert_reqs=none" if os.getenv("DISABLE_REDIS_SSL") else "")
-        redis_client = redis.from_url(redis_url)
-        pubsub = redis_client.pubsub()
-        channel = f"bot_{self.bot_in_db.id}"
-        pubsub.subscribe(channel)
+        self.connect_to_redis()
 
         # Initialize core objects
         # Only used for adapters that can provide per-participant audio
@@ -354,19 +362,39 @@ class BotController:
         # Create GLib main loop
         self.main_loop = GLib.MainLoop()
 
-        # Set up Redis listener in a separate thread
-        import threading
+        def repeatedly_try_to_reconnect_to_redis():
+            reconnect_delay_seconds = 1
+            num_attempts = 0
+            while True:
+                try:
+                    self.pubsub.close()
+                    self.connect_to_redis()
+                    break
+                except Exception as e:
+                    logger.info(f"Error reconnecting to Redis: {e} Attempt {num_attempts} / 30.")
+                    time.sleep(reconnect_delay_seconds)
+                    num_attempts += 1
+                    if num_attempts > 30:
+                        raise Exception("Failed to reconnect to Redis after 30 attempts")
 
         def redis_listener():
             while True:
                 try:
-                    message = pubsub.get_message(timeout=1.0)
+                    message = self.pubsub.get_message(timeout=1.0)
                     if message:
                         # Schedule Redis message handling in the main GLib loop
                         GLib.idle_add(lambda: self.handle_redis_message(message))
                 except Exception as e:
-                    logger.info(f"Error in Redis listener: {e}")
-                    break
+
+                    # If this is a certain type of exception, we can attempt to reconnect
+                    if type(e) == redis.exceptions.ConnectionError and "Connection closed by server." in str(e):
+                        logger.info(f"Redis connection closed by server. Attempting to reconnect...")
+                        repeatedly_try_to_reconnect_to_redis()
+
+                    else:                        
+                        # log the type of exception
+                        logger.info(f"Error in Redis listener: {type(e)} {e}")
+                        break
 
         redis_thread = threading.Thread(target=redis_listener, daemon=True)
         redis_thread.start()
@@ -387,8 +415,8 @@ class BotController:
             self.cleanup()
         finally:
             # Clean up Redis subscription
-            pubsub.unsubscribe(channel)
-            pubsub.close()
+            self.pubsub.unsubscribe(self.channel)
+            self.pubsub.close()
 
     def take_action_based_on_bot_in_db(self):
         if self.bot_in_db.state == BotStates.JOINING:

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -2,6 +2,8 @@ import json
 import logging
 import os
 import signal
+import threading
+import time
 import traceback
 
 import gi
@@ -30,7 +32,7 @@ from bots.models import (
     Utterance,
 )
 from bots.utils import meeting_type_from_url
-import threading
+
 from .audio_output_manager import AudioOutputManager
 from .automatic_leave_configuration import AutomaticLeaveConfiguration
 from .closed_caption_manager import ClosedCaptionManager
@@ -40,7 +42,6 @@ from .individual_audio_input_manager import IndividualAudioInputManager
 from .pipeline_configuration import PipelineConfiguration
 from .rtmp_client import RTMPClient
 from .screen_and_audio_recorder import ScreenAndAudioRecorder
-import time
 
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib
@@ -385,13 +386,12 @@ class BotController:
                         # Schedule Redis message handling in the main GLib loop
                         GLib.idle_add(lambda: self.handle_redis_message(message))
                 except Exception as e:
-
                     # If this is a certain type of exception, we can attempt to reconnect
                     if type(e) == redis.exceptions.ConnectionError and "Connection closed by server." in str(e):
-                        logger.info(f"Redis connection closed by server. Attempting to reconnect...")
+                        logger.info("Redis connection closed by server. Attempting to reconnect...")
                         repeatedly_try_to_reconnect_to_redis()
 
-                    else:                        
+                    else:
                         # log the type of exception
                         logger.info(f"Error in Redis listener: {type(e)} {e}")
                         break

--- a/bots/bot_pod_creator/bot_pod_creator.py
+++ b/bots/bot_pod_creator/bot_pod_creator.py
@@ -71,13 +71,13 @@ class BotPodCreator:
                         command=command,
                         resources=client.V1ResourceRequirements(
                             requests={
-                                "cpu": "4",
-                                "memory": "4Gi",
-                                "ephemeral-storage": "10Gi"
+                                "cpu": os.getenv("BOT_CPU_REQUEST", "4"),
+                                "memory": os.getenv("BOT_MEMORY_REQUEST", "4Gi"),
+                                "ephemeral-storage": os.getenv("BOT_EPHEMERAL_STORAGE_REQUEST", "10Gi")
                             },
                             limits={
-                                "memory": "4Gi",
-                                "ephemeral-storage": "10Gi"
+                                "memory": os.getenv("BOT_MEMORY_LIMIT", "4Gi"),
+                                "ephemeral-storage": os.getenv("BOT_EPHEMERAL_STORAGE_LIMIT", "10Gi")
                             }
                         ),
                         env_from=[


### PR DESCRIPTION
In digital ocean, the bot sometimes loses the pub/sub connection to redis because the server drops the connection. This PR adds code to detect the exception that happens when the server drops the connection and automatically try to reconnect.