### PR TITLE
upgrade zoom meeting sdk version

### DIFF
--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -552,13 +552,12 @@ class ZoomBotAdapter(BotAdapter):
         param.meetingNumber = meeting_number
         param.userName = self.display_name
         param.psw = self.meeting_password if self.meeting_password is not None else ""
-        param.vanityID = ""
-        param.customer_key = ""
-        param.webinarToken = ""
-        param.onBehalfToken = ""
         param.isVideoOff = False
         param.isAudioOff = False
-
+        param.isAudioRawDataStereo = False
+        param.isMyVoiceInMix = False
+        param.eAudioRawdataSamplingRate = zoom.AudioRawdataSamplingRate.AudioRawdataSamplingRate_32K
+        
         join_result = self.meeting_service.Join(join_param)
         logger.info(f"join_result = {join_result}")
 

--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -561,7 +561,7 @@ class ZoomBotAdapter(BotAdapter):
         param.isAudioRawDataStereo = False
         param.isMyVoiceInMix = False
         param.eAudioRawdataSamplingRate = zoom.AudioRawdataSamplingRate.AudioRawdataSamplingRate_32K
-        
+
         join_result = self.meeting_service.Join(join_param)
         logger.info(f"join_result = {join_result}")
 

--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -360,6 +360,10 @@ class ZoomBotAdapter(BotAdapter):
         self.audio_ctrl = self.meeting_service.GetMeetingAudioController()
         self.audio_ctrl_event = zoom.MeetingAudioCtrlEventCallbacks(onUserActiveAudioChangeCallback=self.on_user_active_audio_change_callback)
         self.audio_ctrl.SetEvent(self.audio_ctrl_event)
+        # Raw audio input got borked in the Zoom SDK after 6.3.5.
+        # This is work-around to get it to work again.
+        # See here for more details: https://devforum.zoom.us/t/cant-record-audio-with-linux-meetingsdk-after-6-3-5-6495-error-code-32/130689/5
+        self.audio_ctrl.JoinVoip()
 
         if self.use_raw_recording:
             self.recording_ctrl = self.meeting_service.GetMeetingRecordingController()
@@ -555,7 +559,7 @@ class ZoomBotAdapter(BotAdapter):
         param.isVideoOff = False
         param.isAudioOff = False
         param.isAudioRawDataStereo = False
-        param.isMyVoiceInMix = True
+        param.isMyVoiceInMix = False
         param.eAudioRawdataSamplingRate = zoom.AudioRawdataSamplingRate.AudioRawdataSamplingRate_32K
         
         join_result = self.meeting_service.Join(join_param)

--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -555,7 +555,7 @@ class ZoomBotAdapter(BotAdapter):
         param.isVideoOff = False
         param.isAudioOff = False
         param.isAudioRawDataStereo = False
-        param.isMyVoiceInMix = False
+        param.isMyVoiceInMix = True
         param.eAudioRawdataSamplingRate = zoom.AudioRawdataSamplingRate.AudioRawdataSamplingRate_32K
         
         join_result = self.meeting_service.Join(join_param)

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ websocket-client==1.8.0
 websockets==14.1
 whitenoise==6.8.2
 wsproto==1.2.0
-zoom-meeting-sdk==0.0.19
+zoom-meeting-sdk==0.0.20
 cachetools==5.5.1
 google-api-core==2.24.1
 google-auth==2.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ websocket-client==1.8.0
 websockets==14.1
 whitenoise==6.8.2
 wsproto==1.2.0
-zoom-meeting-sdk==0.0.17
+zoom-meeting-sdk==0.0.20
 cachetools==5.5.1
 google-api-core==2.24.1
 google-auth==2.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ websocket-client==1.8.0
 websockets==14.1
 whitenoise==6.8.2
 wsproto==1.2.0
-zoom-meeting-sdk==0.0.20
+zoom-meeting-sdk==0.0.19
 cachetools==5.5.1
 google-api-core==2.24.1
 google-auth==2.38.0


### PR DESCRIPTION
The zoom meeting sdk for linux after version 6.3.5 has a bug where raw audio doesn't work unless you can join `JoinVoip` after joining. This PR upgrades the sdk, so we needed to add the workaround.