### PR TITLE
Removed lint warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,4 @@
 [tool.ruff]
-# Enable pycodestyle (`E`), Pyflakes (`F`), and import sorting (`I`)
-select = ["E", "F", "I"]
-ignore = ["E501", "E722", "E402", "F403"]
-
-# Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
-unfixable = []
-
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".bzr",
@@ -36,17 +28,26 @@ exclude = [
 # Same as Black.
 line-length = 999  # Setting a very large line length to prevent wrapping
 
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
 # Use Python 3.10
 target-version = "py310"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint]
+# Enable pycodestyle (`E`), Pyflakes (`F`), and import sorting (`I`)
+select = ["E", "F", "I"]
+ignore = ["E501", "E722", "E402", "F403"]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F", "I"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["attendee"]
 
 [tool.ruff.format]


### PR DESCRIPTION
**Previous behavior** 

When linting, a warning would appear: 

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'dummy-variable-rgx' -> 'lint.dummy-variable-rgx'
  - 'fixable' -> 'lint.fixable'
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'unfixable' -> 'lint.unfixable'
  - 'isort' -> 'lint.isort'
  - 'mccabe' -> 'lint.mccabe'
1 file reformatted, 85 files left unchanged

```


**After the fix**

The warnings are no longer emitted.


**To test**

Run `make lint` and ensure there are no file changes—this confirms the linter is behaving as expected on a fully linted project. The warning should then disappear.


