### PR TITLE
feat: Add automatic leave settings to bot configuration

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -288,7 +288,13 @@ class BotController:
         self.pubsub = None
         self.pubsub_channel = f"bot_{self.bot_in_db.id}"
 
-        self.automatic_leave_configuration = AutomaticLeaveConfiguration()
+        auto_leave_settings = self.bot_in_db.settings.get("automatic_leave_settings", {})
+        self.automatic_leave_configuration = AutomaticLeaveConfiguration(
+            silence_threshold_seconds=auto_leave_settings.get("silence_threshold_seconds", 600),
+            only_participant_in_meeting_threshold_seconds=auto_leave_settings.get("only_participant_in_meeting_threshold_seconds", 60),
+            wait_for_host_to_start_meeting_timeout_seconds=auto_leave_settings.get("wait_for_host_to_start_meeting_timeout_seconds", 600),
+            silence_activate_after_seconds=auto_leave_settings.get("silence_activate_after_seconds", 1200)
+        )
 
         if self.bot_in_db.rtmp_destination_url():
             self.pipeline_configuration = PipelineConfiguration.rtmp_streaming_bot()

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -289,12 +289,7 @@ class BotController:
         self.pubsub_channel = f"bot_{self.bot_in_db.id}"
 
         auto_leave_settings = self.bot_in_db.settings.get("automatic_leave_settings", {})
-        self.automatic_leave_configuration = AutomaticLeaveConfiguration(
-            silence_threshold_seconds=auto_leave_settings.get("silence_threshold_seconds", 600),
-            only_participant_in_meeting_threshold_seconds=auto_leave_settings.get("only_participant_in_meeting_threshold_seconds", 60),
-            wait_for_host_to_start_meeting_timeout_seconds=auto_leave_settings.get("wait_for_host_to_start_meeting_timeout_seconds", 600),
-            silence_activate_after_seconds=auto_leave_settings.get("silence_activate_after_seconds", 1200)
-        )
+        self.automatic_leave_configuration = AutomaticLeaveConfiguration(silence_threshold_seconds=auto_leave_settings.get("silence_threshold_seconds", 600), only_participant_in_meeting_threshold_seconds=auto_leave_settings.get("only_participant_in_meeting_threshold_seconds", 60), wait_for_host_to_start_meeting_timeout_seconds=auto_leave_settings.get("wait_for_host_to_start_meeting_timeout_seconds", 600), silence_activate_after_seconds=auto_leave_settings.get("silence_activate_after_seconds", 1200))
 
         if self.bot_in_db.rtmp_destination_url():
             self.pipeline_configuration = PipelineConfiguration.rtmp_streaming_bot()

--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -209,12 +209,14 @@ class BotCreateView(APIView):
         debug_settings = serializer.validated_data["debug_settings"]
         bot_image = serializer.validated_data["bot_image"]
         metadata = serializer.validated_data["metadata"]
+        automatic_leave_settings = serializer.validated_data["automatic_leave_settings"]
 
         settings = {
             "transcription_settings": transcription_settings,
             "rtmp_settings": rtmp_settings,
             "recording_settings": recording_settings,
             "debug_settings": debug_settings,
+            "automatic_leave_settings": automatic_leave_settings,
         }
 
         with transaction.atomic():

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -455,7 +455,7 @@ class CreateBotSerializer(serializers.Serializer):
 
         # Validate that all values are positive integers
         for param, default in defaults.items():
-            if param in value and (not isinstance(value[param], int) or value[param] < 0):
+            if param in value and (not isinstance(value[param], int) or value[param] <= 0):
                 raise serializers.ValidationError(f"{param} must be a positive integer")
             # Set default if not provided
             if param not in value:

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -451,12 +451,7 @@ class CreateBotSerializer(serializers.Serializer):
 
     def validate_automatic_leave_settings(self, value):
         # Set default values if not provided
-        defaults = {
-            'silence_threshold_seconds': 600,
-            'only_participant_in_meeting_threshold_seconds': 60,
-            'wait_for_host_to_start_meeting_timeout_seconds': 600,
-            'silence_activate_after_seconds': 1200
-        }
+        defaults = {"silence_threshold_seconds": 600, "only_participant_in_meeting_threshold_seconds": 60, "wait_for_host_to_start_meeting_timeout_seconds": 600, "silence_activate_after_seconds": 1200}
 
         # Validate that all values are positive integers
         for param, default in defaults.items():

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -443,6 +443,27 @@ class CreateBotSerializer(serializers.Serializer):
 
         return value
 
+    automatic_leave_settings = serializers.DictField(default=dict, required=False)
+
+    def validate_automatic_leave_settings(self, value):
+        # Set default values if not provided
+        defaults = {
+            'silence_threshold_seconds': 600,
+            'only_participant_in_meeting_threshold_seconds': 60,
+            'wait_for_host_to_start_meeting_timeout_seconds': 600,
+            'silence_activate_after_seconds': 1200
+        }
+
+        # Validate that all values are positive integers
+        for param, default in defaults.items():
+            if param in value and (not isinstance(value[param], int) or value[param] < 0):
+                raise serializers.ValidationError(f"{param} must be a positive integer")
+            # Set default if not provided
+            if param not in value:
+                value[param] = default
+
+        return value
+
 
 class BotSerializer(serializers.ModelSerializer):
     id = serializers.CharField(source="object_id")

--- a/bots/tests/test_automatic_leave_settings.py
+++ b/bots/tests/test_automatic_leave_settings.py
@@ -1,0 +1,115 @@
+from django.test import TestCase
+
+from bots.models import Bot, Organization, Project
+
+
+class AutomaticLeaveSettingsTests(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(name="Test Organization")
+        self.project = Project.objects.create(
+            name="Test Project", organization=self.organization
+        )
+
+    def test_automatic_leave_settings_default_values(self):
+        """
+        Test that default automatic leave settings are correctly applied when not specified
+        """
+        # Create a bot with empty settings
+        bot = Bot.objects.create(
+            project=self.project,
+            meeting_url="https://zoom.us/j/123456789",
+            name="Test Bot",
+            settings={},
+        )
+
+        # Extract the automatic leave settings
+        auto_leave_settings = bot.settings.get("automatic_leave_settings", {})
+
+        # Assert default values are used
+        self.assertEqual(auto_leave_settings.get("silence_threshold_seconds", 600), 600)
+        self.assertEqual(
+            auto_leave_settings.get(
+                "only_participant_in_meeting_threshold_seconds", 60
+            ),
+            60,
+        )
+        self.assertEqual(
+            auto_leave_settings.get(
+                "wait_for_host_to_start_meeting_timeout_seconds", 600
+            ),
+            600,
+        )
+        self.assertEqual(
+            auto_leave_settings.get("silence_activate_after_seconds", 1200), 1200
+        )
+
+    def test_automatic_leave_settings_custom_values(self):
+        """
+        Test that custom automatic leave settings are correctly applied
+        """
+        # Create a bot with custom settings
+        custom_settings = {
+            "automatic_leave_settings": {
+                "silence_threshold_seconds": 300,
+                "only_participant_in_meeting_threshold_seconds": 30,
+                "wait_for_host_to_start_meeting_timeout_seconds": 900,
+                "silence_activate_after_seconds": 600,
+            }
+        }
+
+        bot = Bot.objects.create(
+            project=self.project,
+            meeting_url="https://zoom.us/j/123456789",
+            name="Test Bot",
+            settings=custom_settings,
+        )
+
+        # Extract the automatic leave settings
+        auto_leave_settings = bot.settings.get("automatic_leave_settings", {})
+
+        # Assert custom values are used
+        self.assertEqual(auto_leave_settings.get("silence_threshold_seconds"), 300)
+        self.assertEqual(
+            auto_leave_settings.get("only_participant_in_meeting_threshold_seconds"), 30
+        )
+        self.assertEqual(
+            auto_leave_settings.get("wait_for_host_to_start_meeting_timeout_seconds"),
+            900,
+        )
+        self.assertEqual(auto_leave_settings.get("silence_activate_after_seconds"), 600)
+
+    def test_automatic_leave_settings_validation(self):
+        """
+        Test that the validation correctly handles various input types
+        """
+        from bots.serializers import CreateBotSerializer
+        from rest_framework.exceptions import ValidationError
+
+        # Test with valid integers
+        valid_settings = {
+            "silence_threshold_seconds": 300,
+            "only_participant_in_meeting_threshold_seconds": 30,
+            "wait_for_host_to_start_meeting_timeout_seconds": 900,
+            "silence_activate_after_seconds": 600,
+        }
+
+        serializer = CreateBotSerializer()
+        validated_data = serializer.validate_automatic_leave_settings(valid_settings)
+
+        self.assertEqual(validated_data["silence_threshold_seconds"], 300)
+        self.assertEqual(
+            validated_data["only_participant_in_meeting_threshold_seconds"], 30
+        )
+        self.assertEqual(
+            validated_data["wait_for_host_to_start_meeting_timeout_seconds"], 900
+        )
+        self.assertEqual(validated_data["silence_activate_after_seconds"], 600)
+
+        # Test with negative values (should raise ValidationError)
+        invalid_settings = {"silence_threshold_seconds": -300}
+
+        try:
+            serializer.validate_automatic_leave_settings(invalid_settings)
+            self.fail("ValidationError not raised for negative values")
+        except ValidationError:
+            pass  # Exception was correctly raised

--- a/bots/tests/test_automatic_leave_settings.py
+++ b/bots/tests/test_automatic_leave_settings.py
@@ -100,3 +100,12 @@ class AutomaticLeaveSettingsTests(TestCase):
             self.fail("ValidationError not raised for negative values")
         except ValidationError:
             pass  # Exception was correctly raised
+
+        # Test with zero values (should raise ValidationError)
+        zero_settings = {"silence_threshold_seconds": 0}
+
+        try:
+            serializer.validate_automatic_leave_settings(zero_settings)
+            self.fail("ValidationError not raised for zero values")
+        except ValidationError:
+            pass  # Exception was correctly raised

--- a/bots/tests/test_automatic_leave_settings.py
+++ b/bots/tests/test_automatic_leave_settings.py
@@ -6,9 +6,7 @@ from bots.models import Bot, Organization, Project
 class AutomaticLeaveSettingsTests(TestCase):
     def setUp(self):
         self.organization = Organization.objects.create(name="Test Organization")
-        self.project = Project.objects.create(
-            name="Test Project", organization=self.organization
-        )
+        self.project = Project.objects.create(name="Test Project", organization=self.organization)
 
     def test_automatic_leave_settings_default_values(self):
         """
@@ -28,20 +26,14 @@ class AutomaticLeaveSettingsTests(TestCase):
         # Assert default values are used
         self.assertEqual(auto_leave_settings.get("silence_threshold_seconds", 600), 600)
         self.assertEqual(
-            auto_leave_settings.get(
-                "only_participant_in_meeting_threshold_seconds", 60
-            ),
+            auto_leave_settings.get("only_participant_in_meeting_threshold_seconds", 60),
             60,
         )
         self.assertEqual(
-            auto_leave_settings.get(
-                "wait_for_host_to_start_meeting_timeout_seconds", 600
-            ),
+            auto_leave_settings.get("wait_for_host_to_start_meeting_timeout_seconds", 600),
             600,
         )
-        self.assertEqual(
-            auto_leave_settings.get("silence_activate_after_seconds", 1200), 1200
-        )
+        self.assertEqual(auto_leave_settings.get("silence_activate_after_seconds", 1200), 1200)
 
     def test_automatic_leave_settings_custom_values(self):
         """
@@ -69,9 +61,7 @@ class AutomaticLeaveSettingsTests(TestCase):
 
         # Assert custom values are used
         self.assertEqual(auto_leave_settings.get("silence_threshold_seconds"), 300)
-        self.assertEqual(
-            auto_leave_settings.get("only_participant_in_meeting_threshold_seconds"), 30
-        )
+        self.assertEqual(auto_leave_settings.get("only_participant_in_meeting_threshold_seconds"), 30)
         self.assertEqual(
             auto_leave_settings.get("wait_for_host_to_start_meeting_timeout_seconds"),
             900,
@@ -82,8 +72,9 @@ class AutomaticLeaveSettingsTests(TestCase):
         """
         Test that the validation correctly handles various input types
         """
-        from bots.serializers import CreateBotSerializer
         from rest_framework.exceptions import ValidationError
+
+        from bots.serializers import CreateBotSerializer
 
         # Test with valid integers
         valid_settings = {
@@ -97,12 +88,8 @@ class AutomaticLeaveSettingsTests(TestCase):
         validated_data = serializer.validate_automatic_leave_settings(valid_settings)
 
         self.assertEqual(validated_data["silence_threshold_seconds"], 300)
-        self.assertEqual(
-            validated_data["only_participant_in_meeting_threshold_seconds"], 30
-        )
-        self.assertEqual(
-            validated_data["wait_for_host_to_start_meeting_timeout_seconds"], 900
-        )
+        self.assertEqual(validated_data["only_participant_in_meeting_threshold_seconds"], 30)
+        self.assertEqual(validated_data["wait_for_host_to_start_meeting_timeout_seconds"], 900)
         self.assertEqual(validated_data["silence_activate_after_seconds"], 600)
 
         # Test with negative values (should raise ValidationError)

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -683,6 +683,32 @@ components:
             create_debug_recording: false
           description: 'The debug settings for the bot, e.g. {''create_debug_recording'':
             True}.'
+        automatic_leave_settings:
+          type: object
+          properties:
+            silence_threshold_seconds:
+              type: integer
+              description: Number of seconds of continuous silence after which the bot should leave
+              default: 600
+            only_participant_in_meeting_threshold_seconds:
+              type: integer
+              description: Number of seconds to wait before leaving if bot is the only participant
+              default: 60
+            wait_for_host_to_start_meeting_timeout_seconds:
+              type: integer
+              description: Number of seconds to wait for the host to start the meeting
+              default: 600
+            silence_activate_after_seconds:
+              type: integer
+              description: Number of seconds to wait before activating the silence threshold
+              default: 1200
+          required: []
+          default:
+            silence_threshold_seconds: 600
+            only_participant_in_meeting_threshold_seconds: 60
+            wait_for_host_to_start_meeting_timeout_seconds: 600
+            silence_activate_after_seconds: 1200
+          description: 'Settings that control when the bot will automatically leave the meeting'
       required:
       - bot_name
       - meeting_url


### PR DESCRIPTION
### Summary

This PR enables API-level configuration of the `AutomaticLeaveConfiguration` used by the meeting bot. It does **not** change the bot behavior or logic — it simply introduces the ability to pass custom values during bot creation.

Ticket: https://github.com/noah-duncan/attendee/issues/196

### What’s Included

- Added `automatic_leave_settings` to the bot creation API schema
- Defined schema properties for:
  - `silence_threshold_seconds`
  - `only_participant_in_meeting_threshold_seconds`
  - `wait_for_host_to_start_meeting_timeout_seconds`
  - `silence_activate_after_seconds`
- Default values remain the same as in the internal `AutomaticLeaveConfiguration` dataclass

### Example Payload

```json
{
  "automatic_leave_settings": {
    "silence_threshold_seconds": 600,
    "only_participant_in_meeting_threshold_seconds": 60,
    "wait_for_host_to_start_meeting_timeout_seconds": 600,
    "silence_activate_after_seconds": 1200
  }
}
```

### Notes

- All fields are optional; if not provided, defaults will be used
- This change sets the foundation for dynamic control over bot exit behavior based on user-specific needs or meeting contexts

Adding API-level support for configuring `AutomaticLeaveConfiguration` is important because it **decouples static logic from runtime configuration**, making the bot more flexible, user-centric, and easier to integrate into diverse environments. Here's why that matters:

---

### **Why This Feature Matters**

#### 1. **Custom Behavior per Use Case**
Different teams and workflows may require different timeout and leave behaviors. For example:
- A support team may want the bot to wait longer for a host to start a meeting.
- An internal team may want the bot to exit quickly when alone.

By allowing these values to be passed via API, the behavior can be **tailored on a per-bot basis** at creation time.

---

#### 2. **Improved Developer Experience**
Developers integrating with the bot no longer need to:
- Modify the codebase to change timeout values
- Redeploy or hardcode logic for each use case

Instead, they can set parameters dynamically via a simple API payload.

---

#### 3. **Supports Future Automation**
This paves the way for programmatic control of bot behavior as part of larger workflows. For example:
- Creating bots with different leave behaviors based on meeting type
- Dynamically adjusting thresholds for high-priority or low-priority meetings

---

#### 4. **Scalability and Maintainability**
Centralizing configuration in the API:
- Makes the system **easier to maintain**
- Reduces the risk of bugs from manual config changes
- Keeps defaults intact for those who don’t need customization


---

Let me know if this make sense @noah-duncan ! Thanks!